### PR TITLE
Add web dashboard, SD manager, print controls, config UI, and MQTT/Home Assistant support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,10 @@
 {
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
     "recommendations": [
         "Jason2866.esp-decoder",
-        "pioarduino.pioarduino-ide"
+        "pioarduino.pioarduino-ide",
+        "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [
         "ms-vscode.cpptools-extension-pack"

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,7 @@ board_build.partitions = min_spiffs.csv
 lib_deps =
     https://github.com/tzapu/WiFiManager.git#v2.0.17
     bitbank2/unzipLIB@^1.0.0
+    knolleary/PubSubClient@^2.8
  
 build_flags =
     -D CORE_DEBUG_LEVEL=0
@@ -57,6 +58,7 @@ board_build.partitions = min_spiffs.csv
 lib_deps =
     https://github.com/tzapu/WiFiManager.git#v2.0.17
     bitbank2/unzipLIB@^1.0.0
+    knolleary/PubSubClient@^2.8
 build_flags =
     -D CORE_DEBUG_LEVEL=0
     -DFIRMWARE_VERSION=\"0.8.4\"

--- a/src/Folder.ino
+++ b/src/Folder.ino
@@ -118,7 +118,7 @@ void folderUp(File dir) {
  * @brief Delete a model folder from SD: removes all files inside, then the
  * folder itself. Used by the long-press-OK delete feature in the Print menu.
  */
-bool deleteModelFolder(const char *path) {
+bool deleteModelFolder(const char *path, bool showProgress = true) {
   // Pass 1: count entries (deleting hundreds of layer PNGs takes tens of
   // seconds on FAT, so we show a progress bar like the WiFi connect one)
   File dir = SD.open(path);
@@ -148,7 +148,7 @@ bool deleteModelFolder(const char *path) {
     if (isDir) SD.rmdir(full.c_str());
     else SD.remove(full.c_str());
     done++;
-    if (done % 10 == 0 || done == total) {
+    if (showProgress && (done % 10 == 0 || done == total)) {
       int w = (int)(136L * done / total);
       if (w > 136) w = 136;
       if (w > 0) gfx2->fillRect(12, 50, w, 12, ORANGE);

--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -1462,7 +1462,7 @@ void screen23111(){
   byte buttonBackClicked = 0;    
   digitalWrite(FAN, HIGH);
   gfx1->fillScreen(WHITE);
-  digitalWrite(LED, HIGH); 
+  digitalWrite(LED, uvLedEnabled ? HIGH : LOW);
   startTime = millis();
   Duration = 0;
   while (Duration <= ExposureMillis){

--- a/src/Motor.ino
+++ b/src/Motor.ino
@@ -128,9 +128,6 @@ void lift_print(){
   stepper.enableOutputs();
   stepper.move(lift_print_steps_total); 
   while (stepper.distanceToGo()!= 0){
-    #if ENABLE_NETWORK
-    network_loop();
-    #endif
     if (stepper.distanceToGo()==lift_print_steps_fast){
       stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60); 
     }
@@ -214,9 +211,6 @@ void lower_print(){
   stepper.enableOutputs();
   stepper.move(lower_print_steps); 
   while (stepper.distanceToGo()!= 0){
-    #if ENABLE_NETWORK
-    network_loop();
-    #endif
     stepper.run();    
     Duration2 = millis()-startTime2;
     if (Duration2 >= 500 && digitalRead(buttonUp) == LOW && screen == 1111 && print_canceled == false && print_paused == false){
@@ -296,9 +290,6 @@ void lift_finished_print(){
   stepper.enableOutputs();
   stepper.moveTo(lift_finished_print_steps); 
   while (stepper.distanceToGo()!= 0){
-    #if ENABLE_NETWORK
-    network_loop();
-    #endif
     stepper.run();
   }
   stepper.disableOutputs();

--- a/src/Motor.ino
+++ b/src/Motor.ino
@@ -128,6 +128,9 @@ void lift_print(){
   stepper.enableOutputs();
   stepper.move(lift_print_steps_total); 
   while (stepper.distanceToGo()!= 0){
+    #if ENABLE_NETWORK
+    network_loop();
+    #endif
     if (stepper.distanceToGo()==lift_print_steps_fast){
       stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60); 
     }
@@ -211,6 +214,9 @@ void lower_print(){
   stepper.enableOutputs();
   stepper.move(lower_print_steps); 
   while (stepper.distanceToGo()!= 0){
+    #if ENABLE_NETWORK
+    network_loop();
+    #endif
     stepper.run();    
     Duration2 = millis()-startTime2;
     if (Duration2 >= 500 && digitalRead(buttonUp) == LOW && screen == 1111 && print_canceled == false && print_paused == false){
@@ -290,6 +296,9 @@ void lift_finished_print(){
   stepper.enableOutputs();
   stepper.moveTo(lift_finished_print_steps); 
   while (stepper.distanceToGo()!= 0){
+    #if ENABLE_NETWORK
+    network_loop();
+    #endif
     stepper.run();
   }
   stepper.disableOutputs();

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -41,6 +41,7 @@
 #include <HTTPUpdate.h>       // pull-and-flash firmware.bin (self-update)
 #include <esp_wifi.h>      // esp_wifi_restore() for reliable credential erase
 #include <Preferences.h>   // forcePortal flag (survives reboot)
+#include <PubSubClient.h>
 
 // Where the printer checks for a newer firmware (self-update, "Install latest").
 // version.txt must contain two lines: (1) the latest version, e.g. "0.7.0",
@@ -49,6 +50,8 @@
 
 WebServer server(80);
 Preferences netPrefs;
+WiFiClient mqttNet;
+PubSubClient mqttClient(mqttNet);
 // NOTE: no global 'UNZIP zip;' here! The UNZIP object is ~40 KB - declared
 // globally it lands in static .bss and overflows WROOM's DRAM segment
 // (verified: "region dram0_0_seg overflowed"). It is heap-allocated inside
@@ -61,6 +64,9 @@ String modelName;       // e.g. "Benchy"
 bool uploadOk = false;
 bool uploadRejected = false;
 unsigned long otaShownBytes = 0;   // progress counter (upload + web OTA)
+unsigned long mqttLastAttemptMs = 0;
+unsigned long mqttLastPublishMs = 0;
+bool mqttDiscoverySent = false;
 
 extern unsigned long whitePixelsAccum;
 extern bool countPixelsMode;
@@ -480,6 +486,14 @@ long formLong(const char *name, long fallback, long minVal, long maxVal) {
   return v;
 }
 
+String formString(const char *name, const String &fallback, uint16_t maxLen) {
+  if (!server.hasArg(name)) return fallback;
+  String v = server.arg(name);
+  v.trim();
+  if (v.length() > maxLen) v = v.substring(0, maxLen);
+  return v;
+}
+
 void sendApiError(int code, const char *message) {
   String out = "{\"ok\":false,\"error\":\"";
   out += jsonEscape(message);
@@ -741,6 +755,8 @@ bool queueModelPrint(const String &requestedName, String &error) {
 }
 
 String configJson() {
+  bool mqttConfigured = mqttEnabled || mqttHost.length() > 0 || mqttUser.length() > 0 ||
+                        mqttPass.length() > 0 || mqttPort != 1883 || mqttTopic != "TinyMaker";
   String out = "\"locked\":";
   out += printerBusy() ? "true" : "false";
   out += ",\"layerHeight\":";
@@ -769,6 +785,21 @@ String configJson() {
   out += uvLedEnabled ? "false" : "true";
   out += ",\"uvLedEnabled\":";
   out += uvLedEnabled ? "true" : "false";
+  out += ",\"mqttEnabled\":";
+  out += mqttEnabled ? "true" : "false";
+  out += ",\"mqttConfigured\":";
+  out += mqttConfigured ? "true" : "false";
+  out += ",\"mqttHost\":\"";
+  out += jsonEscape(mqttHost);
+  out += "\",\"mqttPort\":";
+  out += String(mqttPort);
+  out += ",\"mqttUser\":\"";
+  out += jsonEscape(mqttUser);
+  out += "\",\"mqttPasswordSet\":";
+  out += mqttPass.length() > 0 ? "true" : "false";
+  out += ",\"mqttTopic\":\"";
+  out += jsonEscape(mqttTopic);
+  out += "\"";
   return out;
 }
 
@@ -786,6 +817,15 @@ void applyConfigRequest() {
   Drop_Back_Feedrate = formLong("drop_back_feedrate", Drop_Back_Feedrate, 20, 50);
   uiTimeoutSecs = formLong("ui_timeout", uiTimeoutSecs, 0, 3600);
   uvLedEnabled = !server.hasArg("dry_run");
+  mqttEnabled = server.hasArg("mqtt_enabled");
+  mqttHost = formString("mqtt_host", mqttHost, 80);
+  mqttPort = formLong("mqtt_port", mqttPort, 1, 65535);
+  mqttUser = formString("mqtt_user", mqttUser, 64);
+  if (server.hasArg("mqtt_password") && server.arg("mqtt_password").length() > 0) {
+    mqttPass = formString("mqtt_password", mqttPass, 64);
+  }
+  mqttTopic = formString("mqtt_topic", mqttTopic, 64);
+  if (mqttTopic.length() == 0) mqttTopic = "TinyMaker";
 
   savePrintSettings();
   saveDeviceConfig();
@@ -802,6 +842,8 @@ void handleApiConfigSave() {
   }
 
   applyConfigRequest();
+  mqttClient.disconnect();
+  mqttDiscoverySent = false;
   sendApiOk(configJson());
 }
 
@@ -812,6 +854,16 @@ void resetWebConfigToDefaults() {
   saveDeviceConfig();
 }
 
+void resetMqttConfigToDefaults() {
+  mqttEnabled = false;
+  mqttHost = "";
+  mqttPort = 1883;
+  mqttUser = "";
+  mqttPass = "";
+  mqttTopic = "TinyMaker";
+  saveDeviceConfig();
+}
+
 void handleApiConfigDefaults() {
   if (printerBusy()) {
     sendApiError(409, "printer busy");
@@ -819,6 +871,18 @@ void handleApiConfigDefaults() {
   }
 
   resetWebConfigToDefaults();
+  sendApiOk(configJson());
+}
+
+void handleApiConfigMqttDefaults() {
+  if (printerBusy()) {
+    sendApiError(409, "printer busy");
+    return;
+  }
+
+  resetMqttConfigToDefaults();
+  mqttClient.disconnect();
+  mqttDiscoverySent = false;
   sendApiOk(configJson());
 }
 
@@ -897,6 +961,179 @@ bool requestPrintStop(String &error) {
   webResumePrint = false;
   if (wasHoming) homing_canceled = true;
   return true;
+}
+
+String mqttBaseTopic() {
+  String base = mqttTopic;
+  base.trim();
+  if (base.length() == 0) base = "TinyMaker";
+  while (base.endsWith("/")) base.remove(base.length() - 1);
+  return base;
+}
+
+String mqttDeviceId() {
+  String id = WiFi.macAddress();
+  id.replace(":", "");
+  id.toLowerCase();
+  return "tinymaker_" + id;
+}
+
+String mqttAvailabilityTopic() {
+  return mqttBaseTopic() + "/status/availability";
+}
+
+const char *mqttFirmwareVersion() {
+#ifdef FIRMWARE_VERSION
+  return FIRMWARE_VERSION;
+#else
+  return "unknown";
+#endif
+}
+
+String mqttDeviceJson() {
+  String id = mqttDeviceId();
+  String out = "{\"identifiers\":[\"";
+  out += id;
+  out += "\"],\"name\":\"TinyMaker\",\"manufacturer\":\"TinyMaker\",\"model\":\"TinyMaker MSLA\",\"sw_version\":\"";
+  out += mqttFirmwareVersion();
+  out += "\"}";
+  return out;
+}
+
+bool mqttPublishRaw(const String &topic, const String &payload, bool retained = false) {
+  return mqttClient.connected() && mqttClient.publish(topic.c_str(), payload.c_str(), retained);
+}
+
+void mqttPublishDiscoveryItem(const char *component, const char *objectSuffix, const char *name,
+                              const String &stateTopic, const char *extra = "") {
+  String id = mqttDeviceId();
+  String objectId = id + "_" + objectSuffix;
+  String topic = "homeassistant/";
+  topic += component;
+  topic += "/";
+  topic += objectId;
+  topic += "/config";
+
+  String payload = "{\"name\":\"";
+  payload += name;
+  payload += "\",\"unique_id\":\"";
+  payload += objectId;
+  payload += "\",\"state_topic\":\"";
+  payload += stateTopic;
+  payload += "\",\"availability_topic\":\"";
+  payload += mqttAvailabilityTopic();
+  payload += "\",\"payload_available\":\"online\",\"payload_not_available\":\"offline\",\"device\":";
+  payload += mqttDeviceJson();
+  if (extra && strlen(extra) > 0) {
+    payload += ",";
+    payload += extra;
+  }
+  payload += "}";
+
+  mqttPublishRaw(topic, payload, true);
+}
+
+void mqttPublishDiscovery() {
+  String base = mqttBaseTopic();
+  mqttPublishDiscoveryItem("sensor", "state", "State", base + "/status/state");
+  mqttPublishDiscoveryItem("binary_sensor", "busy", "Busy", base + "/status/busy",
+                           "\"payload_on\":\"ON\",\"payload_off\":\"OFF\"");
+  mqttPublishDiscoveryItem("binary_sensor", "dry_run", "Dry run", base + "/status/dry_run",
+                           "\"payload_on\":\"ON\",\"payload_off\":\"OFF\"");
+  mqttPublishDiscoveryItem("binary_sensor", "sd_ready", "SD ready", base + "/sd/ready",
+                           "\"payload_on\":\"ON\",\"payload_off\":\"OFF\"");
+  mqttPublishDiscoveryItem("sensor", "wifi_rssi", "WiFi RSSI", base + "/status/wifi_rssi",
+                           "\"device_class\":\"signal_strength\",\"unit_of_measurement\":\"dBm\",\"state_class\":\"measurement\"");
+  mqttPublishDiscoveryItem("sensor", "current_layer", "Current layer", base + "/print/current_layer",
+                           "\"state_class\":\"measurement\"");
+  mqttPublishDiscoveryItem("sensor", "total_layers", "Total layers", base + "/print/total_layers",
+                           "\"state_class\":\"measurement\"");
+  mqttPublishDiscoveryItem("sensor", "resin_used_ml", "Resin used", base + "/print/resin_used_ml",
+                           "\"unit_of_measurement\":\"mL\",\"state_class\":\"measurement\"");
+  mqttPublishDiscoveryItem("sensor", "running_time_sec", "Running time", base + "/print/running_time_sec",
+                           "\"device_class\":\"duration\",\"unit_of_measurement\":\"s\",\"state_class\":\"measurement\"");
+  mqttPublishDiscoveryItem("sensor", "remaining_time_sec", "Remaining time", base + "/print/remaining_time_sec",
+                           "\"device_class\":\"duration\",\"unit_of_measurement\":\"s\",\"state_class\":\"measurement\"");
+  mqttDiscoverySent = true;
+}
+
+void mqttPublishStatus() {
+  bool busy = printerBusy();
+  bool sdReady = busy ? false : sdCardReady();
+  String base = mqttBaseTopic();
+
+  mqttPublishRaw(mqttAvailabilityTopic(), "online", true);
+  mqttPublishRaw(base + "/status/state", printerStateText(), true);
+  mqttPublishRaw(base + "/status/busy", busy ? "ON" : "OFF", true);
+  mqttPublishRaw(base + "/status/dry_run", uvLedEnabled ? "OFF" : "ON", true);
+  mqttPublishRaw(base + "/status/ip", WiFi.localIP().toString(), true);
+  mqttPublishRaw(base + "/status/wifi_rssi", String(WiFi.RSSI()), true);
+  mqttPublishRaw(base + "/sd/ready", sdReady ? "ON" : "OFF", true);
+  mqttPublishRaw(base + "/print/current_layer", String(current_layer), true);
+  mqttPublishRaw(base + "/print/total_layers", String(layer_counter), true);
+  mqttPublishRaw(base + "/print/resin_used_ml", String(resinUsedMl, 1), true);
+  mqttPublishRaw(base + "/print/running_time_sec", String(currentRunSecs()), true);
+  mqttPublishRaw(base + "/print/remaining_time_sec", String(remainingPrintSecs()), true);
+}
+
+void mqttCallback(char *topic, byte *payload, unsigned int length) {
+  String t = topic;
+  if (t != "homeassistant/status") return;
+
+  String msg;
+  for (unsigned int i = 0; i < length; i++) msg += (char)payload[i];
+  if (msg == "online") {
+    mqttDiscoverySent = false;
+  }
+}
+
+bool mqttConnect() {
+  if (!mqttEnabled || mqttHost.length() == 0 || WiFi.status() != WL_CONNECTED) return false;
+
+  mqttClient.setServer(mqttHost.c_str(), mqttPort);
+  mqttClient.setCallback(mqttCallback);
+  mqttClient.setBufferSize(1024);
+  mqttClient.setSocketTimeout(1);
+
+  String id = mqttDeviceId();
+  bool ok;
+  if (mqttUser.length() > 0) {
+    ok = mqttClient.connect(id.c_str(), mqttUser.c_str(), mqttPass.c_str(),
+                            mqttAvailabilityTopic().c_str(), 0, true, "offline");
+  } else {
+    ok = mqttClient.connect(id.c_str(), mqttAvailabilityTopic().c_str(), 0, true, "offline");
+  }
+
+  if (!ok) return false;
+  mqttClient.subscribe("homeassistant/status");
+  mqttPublishRaw(mqttAvailabilityTopic(), "online", true);
+  mqttDiscoverySent = false;
+  mqttLastPublishMs = 0;
+  return true;
+}
+
+void mqtt_loop() {
+  if (!mqttEnabled || mqttHost.length() == 0 || WiFi.status() != WL_CONNECTED) {
+    if (mqttClient.connected()) mqttClient.disconnect();
+    mqttDiscoverySent = false;
+    return;
+  }
+
+  if (!mqttClient.connected()) {
+    unsigned long now = millis();
+    if (now - mqttLastAttemptMs < 10000UL) return;
+    mqttLastAttemptMs = now;
+    if (!mqttConnect()) return;
+  }
+
+  mqttClient.loop();
+  if (!mqttDiscoverySent) mqttPublishDiscovery();
+
+  unsigned long now = millis();
+  if (now - mqttLastPublishMs >= 5000UL) {
+    mqttLastPublishMs = now;
+    mqttPublishStatus();
+  }
 }
 
 void handleApiPrintStart() {
@@ -1028,8 +1265,9 @@ String rootStyledPage(const String &inner) {
     "border-top:1px solid #3a3a3f;padding-top:10px}.file:first-child{border-top:0;padding-top:0}"
     ".rowActions{display:flex;gap:8px;align-items:center}"
     ".meta{font-size:12px;color:#aaa;margin-top:3px}"
-    "input[type=file],input[type=number]{width:100%;margin:6px 0 12px;padding:10px;border:1px solid #555;border-radius:8px;background:#1c1c1e;color:#eee}"
+    "input[type=file],input[type=number],input[type=text],input[type=password]{width:100%;margin:6px 0 12px;padding:10px;border:1px solid #555;border-radius:8px;background:#1c1c1e;color:#eee}"
     "label span{display:block;font-size:13px;color:#aaa}.configGrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px 12px}"
+    ".spanAll{grid-column:1/-1}"
     ".check{display:flex;align-items:center;gap:8px;margin:6px 0 12px}.check input{width:auto}.check span{display:inline;color:#eee}"
     ".actions{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}"
     ".toolbar{display:flex;gap:8px;margin:12px 0}.toolbar button,.toolbar .button{width:auto;flex:1;margin-top:0;background:#3c3c42}"
@@ -1140,9 +1378,21 @@ void handleRootPage() {
     <label><span>Drop back feedrate</span><input name='drop_back_feedrate' id='cfgDropBackFeedrate' type='number' min='20' max='50' step='10'></label>
     <label><span>UI timeout (s, 0=off)</span><input name='ui_timeout' id='cfgUiTimeout' type='number' min='0' max='3600' step='5'></label>
     <label class='check'><input name='dry_run' id='cfgDryRun' type='checkbox' value='1'><span>Dry run mode</span></label>
+    <label class='check spanAll'><input name='mqtt_enabled' id='cfgMqttEnabled' type='checkbox' value='1'><span>Enable MQTT? (SmartHome integration)</span></label>
+    <div id='mqttFields' class='spanAll hidden'>
+      <div class='configGrid'>
+        <label><span>MQTT broker host</span><input name='mqtt_host' id='cfgMqttHost' type='text' maxlength='80' placeholder='192.168.1.10'></label>
+        <label><span>MQTT broker port</span><input name='mqtt_port' id='cfgMqttPort' type='number' min='1' max='65535' step='1'></label>
+        <label><span>MQTT username</span><input name='mqtt_user' id='cfgMqttUser' type='text' maxlength='64' autocomplete='username'></label>
+        <label><span>MQTT password</span><input name='mqtt_password' id='cfgMqttPassword' type='password' maxlength='64' autocomplete='current-password' placeholder='Leave blank to keep current'></label>
+        <label class='spanAll'><span>MQTT topic prefix</span><input name='mqtt_topic' id='cfgMqttTopic' type='text' maxlength='64' placeholder='TinyMaker'></label>
+      </div>
+      <div id='mqttHint' class='hint'>MQTT publishing will use these settings in the SmartHome integration step.</div>
+    </div>
     <button id='configSaveButton' type='submit'>Save config</button>
   </form>
   <button id='configDefaultsButton' class='button secondary' type='button'>Reset to defaults</button>
+  <button id='configMqttResetButton' class='button secondary hidden' type='button'>Reset MQTT</button>
   <div id='configHint' class='hint'>Config locks automatically while printing.</div>
 </section>
 
@@ -1228,12 +1478,18 @@ const startPrint=async nameEnc=>{const name=decodeURIComponent(nameEnc||enc(sele
 const deleteFile=async nameEnc=>{const name=decodeURIComponent(nameEnc);if(!confirm('Delete this SD item?'))return;try{await api('/api/files/delete?name='+enc(name),{method:'POST'});msg('Deleted '+name+'.');loadFiles();}catch(e){msg(e.message,true);}};
 const printCommand=async(cmd,confirmText)=>{if(confirmText&&!confirm(confirmText))return;try{await api('/api/print/'+cmd,{method:'POST'});refreshStatus();}catch(e){msg(e.message,true);}};
 
-const setConfigDisabled=disabled=>{document.querySelectorAll('#configForm input,#configForm button,#configDefaultsButton').forEach(e=>e.disabled=disabled);};
+const setConfigDisabled=disabled=>{document.querySelectorAll('#configForm input,#configForm button,#configDefaultsButton,#configMqttResetButton').forEach(e=>e.disabled=disabled);};
+const updateMqttFields=()=>show('mqttFields',$('cfgMqttEnabled').checked);
 const loadConfig=async()=>{
   try{
     const c=await api('/api/config');
     $('cfgLayerHeight').value=Number(c.layerHeight).toFixed(2); $('cfgBaseExposure').value=c.baseExposure; $('cfgRegularExposure').value=c.regularExposure; $('cfgBaseLayers').value=c.baseLayers; $('cfgTransitionLayers').value=c.transitionLayers;
     $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun;
+    $('cfgMqttEnabled').checked=!!c.mqttEnabled; $('cfgMqttHost').value=c.mqttHost||''; $('cfgMqttPort').value=c.mqttPort||1883; $('cfgMqttUser').value=c.mqttUser||''; $('cfgMqttPassword').value=''; $('cfgMqttTopic').value=c.mqttTopic||'TinyMaker';
+    $('mqttHint').textContent=c.mqttPasswordSet?'Password is saved. Enter a new one only if you want to replace it.':'MQTT password is not set.';
+    updateMqttFields();
+    show('configMqttResetButton',!!c.mqttConfigured);
+    $('configDefaultsButton').textContent=c.mqttConfigured?'Reset to defaults (Excluding MQTT)':'Reset to defaults';
     setConfigDisabled(!!c.locked); $('configHint').textContent=c.locked?'Config is locked while printing.':'Config locks automatically while printing.';
   }catch(e){$('configHint').textContent=e.message;}
 };
@@ -1244,8 +1500,10 @@ window.deleteFile=deleteFile;
 
 $('uploadForm').addEventListener('submit',async e=>{e.preventDefault();const f=$('uploadFile').files[0];if(!f)return;const fd=new FormData();fd.append('file',f);$('uploadButton').disabled=true;$('uploadHint').textContent='Uploading...';try{await api('/upload',{method:'POST',body:fd});$('uploadFile').value='';$('uploadHint').textContent='Upload complete.';loadFiles();}catch(err){$('uploadHint').textContent=err.message;}finally{$('uploadButton').disabled=false;}});
 $('configForm').addEventListener('submit',async e=>{e.preventDefault();try{await api('/api/config',{method:'POST',body:new FormData(e.target)});msg('Config saved.');loadConfig();}catch(err){msg(err.message,true);}});
-$('configDefaultsButton').addEventListener('click',async()=>{if(!confirm('Reset config to defaults?'))return;try{await api('/api/config/defaults',{method:'POST'});msg('Defaults restored.');loadConfig();}catch(e){msg(e.message,true);}});
+$('configDefaultsButton').addEventListener('click',async()=>{const keep=$('configDefaultsButton').textContent.indexOf('MQTT')>=0;if(!confirm(keep?'Reset config to defaults and keep MQTT settings?':'Reset config to defaults?'))return;try{await api('/api/config/defaults',{method:'POST'});msg(keep?'Defaults restored. MQTT settings kept.':'Defaults restored.');loadConfig();}catch(e){msg(e.message,true);}});
+$('configMqttResetButton').addEventListener('click',async()=>{if(!confirm('Reset MQTT settings?'))return;try{await api('/api/config/mqtt/defaults',{method:'POST'});msg('MQTT settings reset.');loadConfig();}catch(e){msg(e.message,true);}});
 $('disableDryRunButton').addEventListener('click',async()=>{if(!confirm('Disable dry run mode? Future prints will use the UV LEDs.'))return;try{await api('/api/config/dry-run?enabled=0',{method:'POST'});msg('Dry run disabled.');loadConfig();refreshStatus();}catch(e){msg(e.message,true);}});
+$('cfgMqttEnabled').addEventListener('change',updateMqttFields);
 $('homeViewButton').addEventListener('click',()=>openView('home'));
 $('configViewButton').addEventListener('click',()=>openView('config'));
 $('modelBackButton').addEventListener('click',()=>openView('home'));
@@ -1450,6 +1708,7 @@ void network_setup() {
   server.on("/api/config", HTTP_GET, handleApiConfigGet);
   server.on("/api/config", HTTP_POST, handleApiConfigSave);
   server.on("/api/config/defaults", HTTP_POST, handleApiConfigDefaults);
+  server.on("/api/config/mqtt/defaults", HTTP_POST, handleApiConfigMqttDefaults);
   server.on("/api/config/dry-run", HTTP_POST, handleApiConfigDryRun);
   server.on("/api/print/start", HTTP_POST, handleApiPrintStart);
   server.on("/api/print/pause", HTTP_POST, handleApiPrintPause);
@@ -1502,6 +1761,7 @@ void network_loop() {
   // Dev espota OTA is answered only while the printer is on the Update screen
   // (same safety gate as the web /update flasher).
   if (otaMenuOpen()) ArduinoOTA.handle();
+  mqtt_loop();
 
   // Live refresh of the WiFi info screen (312): redraw values every 2 s
   // while the screen is open. 'screen' global is defined in the main .ino

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -755,7 +755,7 @@ bool deleteSdItem(const String &requestedName, String &error) {
     return false;
   }
 
-  bool ok = isDir ? deleteModelFolder(path.c_str()) : SD.remove(path.c_str());
+  bool ok = isDir ? deleteModelFolder(path.c_str(), false) : SD.remove(path.c_str());
   if (!ok) {
     error = "delete failed";
     return false;

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -101,6 +101,57 @@ bool sdCardReady() {
   return true;
 }
 
+String uint64Json(uint64_t value) {
+  char buf[24];
+  snprintf(buf, sizeof(buf), "%llu", (unsigned long long)value);
+  return String(buf);
+}
+
+bool sdCardUsage(uint64_t &totalBytes, uint64_t &freeBytes) {
+  totalBytes = 0;
+  freeBytes = 0;
+  if (!sdCardReady()) return false;
+
+  FatVolume *vol = SD.vol();
+  if (!vol) return false;
+
+  int32_t freeClusters = vol->freeClusterCount();
+  if (freeClusters < 0) return false;
+
+  uint64_t bytesPerCluster = (uint64_t)vol->blocksPerCluster() * 512ULL;
+  totalBytes = (uint64_t)vol->clusterCount() * bytesPerCluster;
+  freeBytes = (uint64_t)freeClusters * bytesPerCluster;
+  return totalBytes > 0;
+}
+
+uint64_t sdFolderSize(const String &path) {
+  uint64_t total = 0;
+  File dir = SD.open(path.c_str());
+  if (!dir) return 0;
+
+  while (true) {
+    File entry = dir.openNextFile();
+    if (!entry) break;
+
+    char rawName[160];
+    entry.getName(rawName, sizeof(rawName));
+    String childName = String(rawName);
+    String childPath = childName.startsWith("/") ? childName : path + (path.endsWith("/") ? "" : "/") + childName;
+    bool isDir = entry.isDirectory();
+    uint64_t bytes = isDir ? 0 : (uint64_t)entry.size();
+    entry.close();
+
+    if (isDir) {
+      total += sdFolderSize(childPath);
+    } else {
+      total += bytes;
+    }
+  }
+
+  dir.close();
+  return total;
+}
+
 // Streaming part - called repeatedly with chunks of the multipart body
 void handleUploadData() {
   HTTPUpload &up = server.upload();
@@ -530,7 +581,7 @@ bool rootEntryManaged(const String &name, bool isDir) {
   return lower.endsWith(".sl1") || lower.endsWith(".zip");
 }
 
-String rootStyledPage(const String &inner);
+void sendRootStyledPage(PGM_P bodyBeforeFw, const char *fw, PGM_P bodyAfterFw);
 
 bool validPrintableModel(const String &name) {
   if (!safeRootName(name)) return false;
@@ -557,7 +608,24 @@ void handleApiFiles() {
     return;
   }
 
-  String out = "{\"ok\":true,\"sdReady\":true,\"items\":[";
+  uint64_t totalBytes = 0;
+  uint64_t freeBytes = 0;
+  bool usageOk = sdCardUsage(totalBytes, freeBytes);
+  uint64_t usedBytes = (usageOk && totalBytes >= freeBytes) ? (totalBytes - freeBytes) : 0;
+  int usagePct = (usageOk && totalBytes > 0) ? (int)((usedBytes * 100ULL) / totalBytes) : 0;
+
+  String out = "{\"ok\":true,\"sdReady\":true";
+  out += ",\"usageKnown\":";
+  out += usageOk ? "true" : "false";
+  out += ",\"totalBytes\":\"";
+  out += uint64Json(totalBytes);
+  out += "\",\"freeBytes\":\"";
+  out += uint64Json(freeBytes);
+  out += "\",\"usedBytes\":\"";
+  out += uint64Json(usedBytes);
+  out += "\",\"usagePct\":";
+  out += String(usagePct);
+  out += ",\"items\":[";
   bool first = true;
   int shown = 0;
   int skipped = 0;
@@ -569,7 +637,7 @@ void handleApiFiles() {
     entry.getName(rawName, sizeof(rawName));
     String name = String(rawName);
     bool isDir = entry.isDirectory();
-    uint32_t bytes = isDir ? 0 : entry.size();
+    uint64_t bytes = isDir ? 0 : (uint64_t)entry.size();
     entry.close();
 
     if (!rootEntryManaged(name, isDir)) {
@@ -590,7 +658,10 @@ void handleApiFiles() {
     out += "\",\"printable\":";
     out += isDir ? "true" : "false";
     out += ",\"sizeBytes\":";
-    out += String(bytes);
+    if (isDir) bytes = sdFolderSize("/" + name);
+    out += "\"";
+    out += uint64Json(bytes);
+    out += "\"";
     out += "}";
     shown++;
   }
@@ -785,6 +856,8 @@ String configJson() {
   out += uvLedEnabled ? "false" : "true";
   out += ",\"uvLedEnabled\":";
   out += uvLedEnabled ? "true" : "false";
+  out += ",\"experimentalSlicing\":";
+  out += experimentalSlicingEnabled ? "true" : "false";
   out += ",\"mqttEnabled\":";
   out += mqttEnabled ? "true" : "false";
   out += ",\"mqttConfigured\":";
@@ -817,6 +890,7 @@ void applyConfigRequest() {
   Drop_Back_Feedrate = formLong("drop_back_feedrate", Drop_Back_Feedrate, 20, 50);
   uiTimeoutSecs = formLong("ui_timeout", uiTimeoutSecs, 0, 3600);
   uvLedEnabled = !server.hasArg("dry_run");
+  experimentalSlicingEnabled = server.hasArg("experimental_slicing");
   mqttEnabled = server.hasArg("mqtt_enabled");
   mqttHost = formString("mqtt_host", mqttHost, 80);
   mqttPort = formLong("mqtt_port", mqttPort, 1, 65535);
@@ -851,6 +925,7 @@ void resetWebConfigToDefaults() {
   resetSettingsToDefault();
   uiTimeoutSecs = 0;
   uvLedEnabled = true;
+  experimentalSlicingEnabled = false;
   saveDeviceConfig();
 }
 
@@ -926,6 +1001,9 @@ bool requestPrintPause(String &error) {
 }
 
 bool requestPrintResume(String &error) {
+  if (printerBusy() && current_state == 7) {
+    return true;
+  }
   if (!printerBusy() || current_state != 6) {
     error = "printer is not paused";
     return false;
@@ -943,8 +1021,7 @@ bool requestPrintStop(String &error) {
     return false;
   }
   if (current_state == 4) {
-    error = "printer is already stopping";
-    return false;
+    return true;
   }
 
   bool wasHoming = current_state == 0;
@@ -1061,6 +1138,9 @@ void mqttPublishStatus() {
   bool busy = printerBusy();
   bool sdReady = busy ? false : sdCardReady();
   String base = mqttBaseTopic();
+  int mqttCurrentLayer = busy ? current_layer : 0;
+  int mqttTotalLayers = busy ? layer_counter : 0;
+  double mqttResinMl = busy ? resinUsedMl : 0.0;
 
   mqttPublishRaw(mqttAvailabilityTopic(), "online", true);
   mqttPublishRaw(base + "/status/state", printerStateText(), true);
@@ -1069,9 +1149,9 @@ void mqttPublishStatus() {
   mqttPublishRaw(base + "/status/ip", WiFi.localIP().toString(), true);
   mqttPublishRaw(base + "/status/wifi_rssi", String(WiFi.RSSI()), true);
   mqttPublishRaw(base + "/sd/ready", sdReady ? "ON" : "OFF", true);
-  mqttPublishRaw(base + "/print/current_layer", String(current_layer), true);
-  mqttPublishRaw(base + "/print/total_layers", String(layer_counter), true);
-  mqttPublishRaw(base + "/print/resin_used_ml", String(resinUsedMl, 1), true);
+  mqttPublishRaw(base + "/print/current_layer", String(mqttCurrentLayer), true);
+  mqttPublishRaw(base + "/print/total_layers", String(mqttTotalLayers), true);
+  mqttPublishRaw(base + "/print/resin_used_ml", String(mqttResinMl, 1), true);
   mqttPublishRaw(base + "/print/running_time_sec", String(currentRunSecs()), true);
   mqttPublishRaw(base + "/print/remaining_time_sec", String(remainingPrintSecs()), true);
 }
@@ -1094,6 +1174,7 @@ bool mqttConnect() {
   mqttClient.setCallback(mqttCallback);
   mqttClient.setBufferSize(1024);
   mqttClient.setSocketTimeout(1);
+  mqttClient.setKeepAlive(120);
 
   String id = mqttDeviceId();
   bool ok;
@@ -1116,6 +1197,18 @@ void mqtt_loop() {
   if (!mqttEnabled || mqttHost.length() == 0 || WiFi.status() != WL_CONNECTED) {
     if (mqttClient.connected()) mqttClient.disconnect();
     mqttDiscoverySent = false;
+    return;
+  }
+
+  if (printerBusy()) {
+    if (mqttClient.connected()) {
+      mqttClient.loop();
+      unsigned long now = millis();
+      if (now - mqttLastPublishMs >= 10000UL) {
+        mqttLastPublishMs = now;
+        mqttPublishStatus();
+      }
+    }
     return;
   }
 
@@ -1184,6 +1277,9 @@ void handleApiStatus() {
   bool busy = printerBusy();
   bool connected = WiFi.status() == WL_CONNECTED;
   bool sdReady = busy ? false : sdCardReady();
+  int statusCurrentLayer = busy ? current_layer : 0;
+  int statusTotalLayers = busy ? layer_counter : 0;
+  double statusResinMl = busy ? resinUsedMl : 0.0;
 
   String out = "{";
   out += "\"busy\":";
@@ -1223,15 +1319,15 @@ void handleApiStatus() {
   out += ",\"lifetimePrintTime\":\"";
   out += formatDuration(totalPrintSecs);
   out += "\",\"currentLayer\":";
-  out += String(current_layer);
+  out += String(statusCurrentLayer);
   out += ",\"totalLayers\":";
-  out += String(layer_counter);
+  out += String(statusTotalLayers);
   out += ",\"layerText\":\"";
-  out += String(current_layer) + " / " + String(layer_counter);
+  out += String(statusCurrentLayer) + " / " + String(statusTotalLayers);
   out += "\",\"resinUsedMl\":";
-  out += String(resinUsedMl, 1);
+  out += String(statusResinMl, 1);
   out += ",\"resinText\":\"";
-  out += String(resinUsedMl, 1) + " ml";
+  out += String(statusResinMl, 1) + " ml";
   out += "\",\"runSecs\":";
   out += String(currentRunSecs());
   out += ",\"runTime\":\"";
@@ -1245,8 +1341,10 @@ void handleApiStatus() {
   server.send(200, "application/json", out);
 }
 
-String rootStyledPage(const String &inner) {
-  return String(
+void sendRootStyledPage(PGM_P bodyBeforeFw, const char *fw, PGM_P bodyAfterFw) {
+  server.setContentLength(CONTENT_LENGTH_UNKNOWN);
+  server.send(200, "text/html", "");
+  server.sendContent_P(PSTR(
     "<!DOCTYPE html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>"
     "<title>TinyMaker</title>"
     "<link rel='icon' href=\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'>"
@@ -1272,8 +1370,14 @@ String rootStyledPage(const String &inner) {
     ".actions{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}"
     ".toolbar{display:flex;gap:8px;margin:12px 0}.toolbar button,.toolbar .button{width:auto;flex:1;margin-top:0;background:#3c3c42}"
     ".banner{background:#3a2818;border-color:#e8720c}.banner strong{display:block;color:#ffb15f;margin-bottom:4px}"
+    ".fitOk{color:#5fd08a}.fitBad{color:#ff6b5f}"
+    ".profileBox{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin-top:10px}"
+    ".previewGrid{display:grid;grid-template-columns:1fr;gap:10px;margin-top:12px}"
+    ".previewCanvas{width:100%;aspect-ratio:4/3;background:#111;border:1px solid #555;border-radius:8px;image-rendering:pixelated}"
     ".progress{height:10px;border:1px solid #555;border-radius:999px;overflow:hidden;background:#1c1c1e;margin-top:10px}"
     ".progress span{display:block;height:100%;width:45%;background:#e8720c;animation:barMove 1.1s infinite linear}"
+    ".storageBar{height:10px;border:1px solid #555;border-radius:999px;overflow:hidden;background:#1c1c1e;margin-top:8px}"
+    ".storageBar span{display:block;height:100%;width:0;background:#e8720c;transition:width .2s ease}"
     "@keyframes barMove{0%{transform:translateX(-110%)}100%{transform:translateX(230%)}}"
     "button,.button{display:inline-block;width:100%;border:0;border-radius:8px;background:#e8720c;color:#fff;padding:12px 14px;"
     "font-size:15px;font-weight:600;text-align:center;text-decoration:none;cursor:pointer}"
@@ -1284,19 +1388,24 @@ String rootStyledPage(const String &inner) {
     ".hidden{display:none}"
     ".hint{font-size:13px;color:#aaa;margin:10px 0 0;line-height:1.4}"
     ".configGrid .hint{grid-column:1/-1}"
-    "@media(max-width:520px){.grid,.configGrid,.actions{grid-template-columns:1fr}.head{display:block}.fw{margin-top:4px}.file{align-items:flex-start;flex-direction:column}.rowActions{width:100%}}"
-    "</style></head><body><main class='wrap'>") + inner + "</main></body></html>";
+    "@media(max-width:520px){.grid,.configGrid,.actions,.profileBox{grid-template-columns:1fr}.head{display:block}.fw{margin-top:4px}.file{align-items:flex-start;flex-direction:column}.rowActions{width:100%}}"
+    "</style></head><body><main class='wrap'>"));
+  server.sendContent_P(bodyBeforeFw);
+  server.sendContent(fw);
+  server.sendContent_P(bodyAfterFw);
+  server.sendContent_P(PSTR("</main></body></html>"));
 }
 
 void handleRootPage() {
-  String fw =
+  const char *fw =
 #ifdef FIRMWARE_VERSION
     FIRMWARE_VERSION;
 #else
     "unknown";
 #endif
-  String inner = R"SPA(
-<div class='head'><div><h1>TinyMaker</h1><div class='fw'>Firmware <span id='fwVersion'>{{FW}}</span></div></div></div>
+  static const char rootBodyBeforeFw[] PROGMEM = R"SPA(
+<div class='head'><div><h1>TinyMaker</h1><div class='fw'>Firmware <span id='fwVersion'>)SPA";
+  static const char rootBodyAfterFw[] PROGMEM = R"SPA(</span></div></div></div>
 
 <section id='dryRunBanner' class='card banner hidden'>
   <strong>Dry run mode enabled.</strong>
@@ -1306,6 +1415,7 @@ void handleRootPage() {
 
 <div class='toolbar'>
   <button id='homeViewButton' type='button'>Dashboard</button>
+  <button id='slicerViewButton' class='hidden' type='button'>Slicer</button>
   <button id='configViewButton' type='button'>Config</button>
   <a class='button secondary' href='/update'>Update</a>
 </div>
@@ -1337,6 +1447,11 @@ void handleRootPage() {
 
   <section class='card'>
     <h2>SD manager</h2>
+    <div id='sdUsageBox' class='hidden' style='margin-bottom:12px'>
+      <div class='label'>SD memory usage</div>
+      <div id='sdUsageText' class='value'>-</div>
+      <div class='storageBar'><span id='sdUsageBar'></span></div>
+    </div>
     <form id='uploadForm'>
       <input id='uploadFile' type='file' name='file' accept='.sl1,.zip' required>
       <button id='uploadButton' type='submit'>Upload model</button>
@@ -1362,6 +1477,44 @@ void handleRootPage() {
   </div>
 </section>
 
+<section id='slicerView' class='card hidden'>
+  <button id='slicerBackButton' class='button secondary' type='button'>Back to dashboard</button>
+  <h2>Prepare model</h2>
+  <div class='hint warn'>Beta slicer. Proceed with caution: STL files must already be the right way up; this does not add supports, hollow models, repair geometry, or optimize orientation.</div>
+  <input id='slicerFile' type='file' accept='.stl' />
+  <div class='profileBox'>
+    <div><div class='label'>Build area</div><div class='value'>40.8 x 30.6 mm</div></div>
+    <div><div class='label'>Max height</div><div class='value'>60 mm</div></div>
+    <div><div class='label'>LCD</div><div class='value'>320 x 240 px</div></div>
+  </div>
+  <div class='previewGrid'>
+    <div>
+      <div class='label'>Model preview</div>
+      <canvas id='modelPreviewCanvas' class='previewCanvas' width='320' height='240'></canvas>
+    </div>
+    <div id='layerPreviewBox' class='hidden'>
+      <div class='label'>Layer preview <span id='layerPreviewLabel'></span></div>
+      <canvas id='layerPreviewCanvas' class='previewCanvas' width='320' height='240'></canvas>
+      <input id='layerPreviewRange' type='range' min='1' max='1' value='1'>
+    </div>
+  </div>
+  <div class='grid' style='margin-top:12px'>
+    <div><div class='label'>Model size</div><div id='slicerSize' class='value'>-</div></div>
+    <div><div class='label'>Scaled size</div><div id='slicerScaledSize' class='value'>-</div></div>
+    <div><div class='label'>Scale</div><div id='slicerScaleValue' class='value'>100%</div></div>
+    <div><div class='label'>Fit check</div><div id='slicerFit' class='value'>Load STL</div></div>
+  </div>
+  <label><span>Scale (%)</span><input id='slicerScale' type='number' min='1' max='1000' step='1' value='100'></label>
+  <div id='slicerProgress' class='progress hidden'><span></span></div>
+  <div class='actions'>
+    <button id='slicerFitButton' type='button' disabled>Scale to fit</button>
+    <button id='slicerSliceButton' type='button' disabled>Slice to ZIP</button>
+    <button id='slicerDownloadButton' class='secondaryBtn' type='button' disabled>Download ZIP</button>
+    <button id='slicerUploadButton' type='button' disabled>Upload sliced ZIP</button>
+  </div>
+  <div id='slicerHint' class='hint'>STL fit checking is active. Layer slicing and ZIP generation are the next step.</div>
+</section>
+
 <section id='configView' class='card hidden'>
   <button id='configBackButton' class='button secondary' type='button'>Back to dashboard</button>
   <h2>Config</h2>
@@ -1378,6 +1531,7 @@ void handleRootPage() {
     <label><span>Drop back feedrate</span><input name='drop_back_feedrate' id='cfgDropBackFeedrate' type='number' min='20' max='50' step='10'></label>
     <label><span>UI timeout (s, 0=off)</span><input name='ui_timeout' id='cfgUiTimeout' type='number' min='0' max='3600' step='5'></label>
     <label class='check'><input name='dry_run' id='cfgDryRun' type='checkbox' value='1'><span>Dry run mode</span></label>
+    <label class='check'><input name='experimental_slicing' id='cfgExperimentalSlicing' type='checkbox' value='1'><span>Enable experimental slicing</span></label>
     <label class='check spanAll'><input name='mqtt_enabled' id='cfgMqttEnabled' type='checkbox' value='1'><span>Enable MQTT? (SmartHome integration)</span></label>
     <div id='mqttFields' class='spanAll hidden'>
       <div class='configGrid'>
@@ -1398,24 +1552,92 @@ void handleRootPage() {
 
 <script>
 const $=id=>document.getElementById(id);
-let statusData=null,selectedModel='';
+let statusData=null,selectedModel='',sdFreeBytes=0,sdTotalBytes=0,slicingEnabled=false;
 const setText=(id,v)=>{const e=$(id);if(e)e.textContent=v;};
 const show=(id,on)=>{const e=$(id);if(e)e.classList.toggle('hidden',!on);};
 const enc=v=>encodeURIComponent(v||'').replace(/'/g,'%27');
 const esc=v=>String(v||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-const api=async(path,opt)=>{const r=await fetch(path,Object.assign({cache:'no-store'},opt||{}));let j={};try{j=await r.json();}catch(e){}if(!r.ok||j.ok===false)throw new Error(j.error||('HTTP '+r.status));return j;};
+const api=async(path,opt,timeoutMs)=>{
+  const o=Object.assign({cache:'no-store'},opt||{});let timer=null,ctrl=null;
+  if(timeoutMs&&typeof AbortController!=='undefined'){ctrl=new AbortController();o.signal=ctrl.signal;timer=setTimeout(()=>ctrl.abort(),timeoutMs);}
+  try{
+    const r=await fetch(path,o);let j={};try{j=await r.json();}catch(e){}
+    if(!r.ok||j.ok===false)throw new Error(j.error||('HTTP '+r.status));
+    return j;
+  }catch(e){if(e.name==='AbortError')throw new Error('timeout');throw e;}
+  finally{if(timer)clearTimeout(timer);}
+};
 const msg=(t,warn)=>{const e=$('statusMsg');e.textContent=t||'';e.classList.toggle('warn',!!warn);};
+const bytesNum=v=>Number(v||0)||0;
+const formatBytes=v=>{
+  let n=bytesNum(v),u=['B','KB','MB','GB'],i=0;
+  while(n>=1024&&i<u.length-1){n/=1024;i++;}
+  return (i? n.toFixed(n<10?1:0):Math.round(n))+' '+u[i];
+};
+const formatShortTime=ms=>{
+  const s=Math.max(0,Math.floor(ms/1000)),m=Math.floor(s/60),r=s%60;
+  return m?m+'m '+r+'s':r+'s';
+};
+const uploadRequiredBytes=bytes=>Math.ceil(bytesNum(bytes)*2.1);
+const checkUploadFits=(bytes,hintEl)=>{
+  if(!sdFreeBytes)return true;
+  const need=uploadRequiredBytes(bytes);
+  if(need<=sdFreeBytes)return true;
+  hintEl.textContent='Not enough SD space. Need about '+formatBytes(need)+' free while importing; available '+formatBytes(sdFreeBytes)+'.';
+  return false;
+};
+const updateSdUsage=d=>{
+  sdFreeBytes=d&&d.usageKnown?bytesNum(d.freeBytes):0;
+  sdTotalBytes=d&&d.usageKnown?bytesNum(d.totalBytes):0;
+  show('sdUsageBox',!!(d&&d.usageKnown));
+  if(!(d&&d.usageKnown))return;
+  const used=bytesNum(d.usedBytes),pct=Math.max(0,Math.min(100,Number(d.usagePct)||0));
+  setText('sdUsageText',formatBytes(used)+' / '+formatBytes(sdTotalBytes)+' ('+pct+'%)');
+  $('sdUsageBar').style.width=pct+'%';
+};
+const uploadWithProgress=(fd,hintEl)=>{
+  const started=Date.now();
+  let lastLoaded=0,total=0;
+  const render=()=>{
+    const elapsed=Date.now()-started, pct=total?Math.round(lastLoaded*100/total):0;
+    const speed=elapsed>0?formatBytes(lastLoaded/(elapsed/1000))+'/s':'-';
+    hintEl.textContent='Uploading'+(total?' '+pct+'%':'')+' - '+formatShortTime(elapsed)+' - '+speed;
+  };
+  return new Promise((resolve,reject)=>{
+    const xhr=new XMLHttpRequest();
+    const timer=setInterval(render,500);
+    xhr.open('POST','/upload');
+    xhr.upload.onprogress=e=>{lastLoaded=e.loaded||lastLoaded;total=e.lengthComputable?e.total:total;render();};
+    xhr.onload=()=>{
+      clearInterval(timer);
+      let j={};try{j=JSON.parse(xhr.responseText||'{}');}catch(e){}
+      if(xhr.status>=200&&xhr.status<300&&j.ok!==false)resolve(j);
+      else reject(new Error(j.error||('HTTP '+xhr.status)));
+    };
+    xhr.onerror=()=>{clearInterval(timer);reject(new Error('upload failed'));};
+    xhr.onabort=()=>{clearInterval(timer);reject(new Error('upload cancelled'));};
+    render();
+    xhr.send(fd);
+  });
+};
+const BUILD={x:40.8,y:30.6,z:60,px:320,py:240};
+let slicerModel=null,slicedZip=null;
+let statusInFlight=false,statusFailCount=0,pendingPrintCmd='',pendingPrintInFlight=false,localPrintStartedAt=0;
 const openView=view=>{
+  if(view==='slicer'&&!slicingEnabled){msg('Experimental slicing is disabled in Config.',true);view='config';}
   show('homeView',view==='home');
   show('modelPanel',view==='model');
+  show('slicerView',view==='slicer');
   show('configView',view==='config');
   if(view==='home')loadFiles();
   if(view==='config')loadConfig();
 };
 
-const refreshStatus=async()=>{
-  try{
-    const s=await api('/api/status'); const was=statusData&&statusData.busy; statusData=s;
+const applyStatus=s=>{
+    const was=statusData&&statusData.busy; statusData=s;
+    if(s.busy&&typeof s.runSecs==='number')localPrintStartedAt=Date.now()-s.runSecs*1000;
+    if(!s.busy)localPrintStartedAt=0;
+    if((pendingPrintCmd==='stop'&&s.stopping)||(pendingPrintCmd==='pause'&&(s.pausing||s.paused))||(pendingPrintCmd==='resume'&&s.resuming))pendingPrintCmd='';
     setText('stateValue',s.state); setText('wifiValue',s.wifiText); setText('ipValue',s.ip); setText('lifetimeValue',s.lifetimePrintTime); setText('sdValue',s.sdText);
     setText('layerValue',s.layerText); setText('resinValue',s.resinText); setText('runValue',s.runTime); setText('remainingValue',s.remainingTime);
     show('dryRunBanner',!!s.dryRun);
@@ -1432,10 +1654,34 @@ const refreshStatus=async()=>{
     resume.disabled=!s.canResume;
     $('stopButton').textContent=s.stopping?'Stopping...':'Stop';
     $('stopButton').disabled=!s.canStop;
+    applyPendingPrintUi();
+    if(!$('configView').classList.contains('hidden')){
+      setConfigDisabled(configIsLocallyLocked());
+      if(configIsLocallyLocked())$('configHint').textContent='Config is locked while printing.';
+    }
     $('uploadButton').disabled=s.busy||!s.sdReady; $('uploadFile').disabled=s.busy||!s.sdReady;
     if(s.busy){$('uploadHint').textContent='Uploads and SD actions are disabled while the printer is busy.';} else if(!s.sdReady){$('uploadHint').textContent='Insert an SD card before uploading or managing models.';} else {$('uploadHint').textContent='Uploaded SL1/ZIP files are unpacked into printable model folders on the SD card.';}
     if(was!==s.busy){loadFiles();loadConfig();}
-  }catch(e){msg('Status unavailable: '+e.message,true);}
+};
+const localBusyStatus=(state,code)=>Object.assign({},statusData||{},{
+  busy:true,paused:false,pausing:false,resuming:false,stopping:false,dryRun:statusData&&statusData.dryRun,
+  canPause:false,canResume:false,canStop:true,state:state,stateCode:code,wifiText:statusData?statusData.wifiText:'-',ip:statusData?statusData.ip:'-',
+  sdReady:false,sdText:'Locked',lifetimePrintTime:statusData?statusData.lifetimePrintTime:'-',layerText:statusData?statusData.layerText:'-',
+  resinText:statusData?statusData.resinText:'-',runSecs:statusData?statusData.runSecs:0,runTime:statusData?statusData.runTime:'0m 0s',remainingTime:statusData?statusData.remainingTime:'-'
+});
+const refreshStatus=async()=>{
+  if(statusInFlight)return;
+  statusInFlight=true;
+  try{
+    const s=await api('/api/status',null,30000);
+    statusFailCount=0;
+    applyStatus(s);
+    if(!pendingPrintCmd)msg('',false);
+  }catch(e){
+    statusFailCount++;
+    if(statusData&&statusData.busy)msg('Syncing with printer at the next safe network window...',true);
+    else msg('Status unavailable: '+e.message,true);
+  }finally{statusInFlight=false;}
 };
 
 const loadFiles=async()=>{
@@ -1443,17 +1689,19 @@ const loadFiles=async()=>{
   if(statusData&&statusData.busy){list.innerHTML='<div class="hint warn">SD manager actions are disabled while printing.</div>';return;}
   try{
     const d=await api('/api/files');
+    updateSdUsage(d);
     if(!d.items.length){list.innerHTML='<div class="hint">No printable model folders or SL1/ZIP archives found.</div>';return;}
     let h='';
     d.items.forEach(it=>{
-      const meta=it.type==='model'?'Model folder':('Archive - '+Math.ceil((it.sizeBytes||0)/1024)+' KB');
+      const size=formatBytes(it.sizeBytes);
+      const meta=(it.type==='model'?'Model folder':'Archive')+' - '+size;
       h+='<div class="file"><div><strong>'+esc(it.name)+'</strong><div class="meta">'+esc(meta)+'</div></div><div class="rowActions">';
       if(it.type==='model')h+='<button class="small secondaryBtn" onclick="modelDetails(\''+enc(it.name)+'\',false)">Details</button><button class="small" onclick="startPrint(\''+enc(it.name)+'\')">Start</button>';
       h+='<button class="delete" onclick="deleteFile(\''+enc(it.name)+'\')">Delete</button></div></div>';
     });
     if(d.hiddenCount>0)h+='<div class="hint">'+d.hiddenCount+' other SD item(s) hidden.</div>';
     list.innerHTML=h;
-  }catch(e){list.innerHTML='<div class="hint warn">'+e.message+'</div>';}
+  }catch(e){updateSdUsage(null);list.innerHTML='<div class="hint warn">'+e.message+'</div>';}
 };
 
 const modelDetails=async(nameEnc,estimate)=>{
@@ -1474,51 +1722,286 @@ const modelDetails=async(nameEnc,estimate)=>{
   finally{$('modelMlButton').disabled=false;$('modelMlButton').textContent='Calculate ml';show('modelProgress',false);}
 };
 
-const startPrint=async nameEnc=>{const name=decodeURIComponent(nameEnc||enc(selectedModel));if(!name||!confirm('Start this print?'))return;try{await api('/api/print/start?name='+enc(name),{method:'POST'});msg('Print queued.');openView('home');refreshStatus();}catch(e){msg(e.message,true);}};
+const applyPendingPrintUi=()=>{
+  if(!pendingPrintCmd)return;
+  if(pendingPrintCmd==='pause'){$('pauseButton').textContent='Pause requested...';$('pauseButton').disabled=true;}
+  if(pendingPrintCmd==='resume'){$('resumeButton').textContent='Resume requested...';$('resumeButton').disabled=true;}
+  if(pendingPrintCmd==='stop'){$('stopButton').textContent='Stop requested...';$('stopButton').disabled=true;}
+};
+const retryPendingPrintCommand=async()=>{
+  if(!pendingPrintCmd||pendingPrintInFlight)return;
+  pendingPrintInFlight=true;
+  const cmd=pendingPrintCmd;
+  try{
+    await api('/api/print/'+cmd,{method:'POST'},30000);
+    pendingPrintCmd='';
+    msg((cmd==='stop'?'Stop':cmd==='pause'?'Pause':'Resume')+' accepted.');
+    refreshStatus();
+  }catch(e){
+    if(e.message.indexOf('not printing')>=0||e.message.indexOf('not paused')>=0){pendingPrintCmd='';msg(e.message,true);}
+    else msg((cmd==='stop'?'Stop':cmd==='pause'?'Pause':'Resume')+' requested. Waiting for the next safe network window...',true);
+  }finally{pendingPrintInFlight=false;applyPendingPrintUi();}
+};
+const startPrint=async nameEnc=>{const name=decodeURIComponent(nameEnc||enc(selectedModel));if(!name||!confirm('Start this print?'))return;try{await api('/api/print/start?name='+enc(name),{method:'POST'},8000);msg('Print queued. Waiting for printer sync...');localPrintStartedAt=Date.now();applyStatus(localBusyStatus('Homing',0));openView('home');refreshStatus();}catch(e){msg(e.message,true);}};
 const deleteFile=async nameEnc=>{const name=decodeURIComponent(nameEnc);if(!confirm('Delete this SD item?'))return;try{await api('/api/files/delete?name='+enc(name),{method:'POST'});msg('Deleted '+name+'.');loadFiles();}catch(e){msg(e.message,true);}};
-const printCommand=async(cmd,confirmText)=>{if(confirmText&&!confirm(confirmText))return;try{await api('/api/print/'+cmd,{method:'POST'});refreshStatus();}catch(e){msg(e.message,true);}};
+const printCommand=async(cmd,confirmText)=>{if(confirmText&&!confirm(confirmText))return;pendingPrintCmd=cmd;applyPendingPrintUi();msg((cmd==='stop'?'Stop':cmd==='pause'?'Pause':'Resume')+' requested. Waiting for printer connection...',true);retryPendingPrintCommand();};
+const tickLocalStatus=()=>{
+  if(statusData&&statusData.busy&&localPrintStartedAt){
+    setText('runValue',formatShortTime(Date.now()-localPrintStartedAt));
+  }
+};
+
+const fmtMm=v=>Number(v).toFixed(2)+' mm';
+const slicerSetFit=(ok,text)=>{const e=$('slicerFit');e.textContent=text;e.classList.toggle('fitOk',ok);e.classList.toggle('fitBad',!ok);};
+const clearLayerPreview=()=>{show('layerPreviewBox',false);const c=$('layerPreviewCanvas'),ctx=c.getContext('2d');ctx.fillStyle='#111';ctx.fillRect(0,0,c.width,c.height);};
+const drawModelPreview=()=>{
+  const c=$('modelPreviewCanvas'),ctx=c.getContext('2d');ctx.fillStyle='#111';ctx.fillRect(0,0,c.width,c.height);
+  ctx.strokeStyle='#444';ctx.lineWidth=1;ctx.strokeRect(0.5,0.5,c.width-1,c.height-1);
+  if(!slicerModel){ctx.fillStyle='#777';ctx.font='14px sans-serif';ctx.textAlign='center';ctx.fillText('Load STL',c.width/2,c.height/2);return;}
+  const scale=Math.max(1,Number($('slicerScale').value)||100)/100, tris=slicerModel.bounds.tris, step=Math.max(1,Math.ceil(tris.length/2500));
+  const map=p=>{const t=transformPt(p,scale);return {x:t.x/BUILD.x*c.width,y:c.height-(t.y/BUILD.y*c.height)};};
+  ctx.strokeStyle='#e8720c';ctx.globalAlpha=.28;ctx.lineWidth=.8;
+  for(let i=0;i<tris.length;i+=step){
+    const a=map(tris[i][0]),b=map(tris[i][1]),d=map(tris[i][2]);
+    ctx.beginPath();ctx.moveTo(a.x,a.y);ctx.lineTo(b.x,b.y);ctx.lineTo(d.x,d.y);ctx.closePath();ctx.stroke();
+  }
+  ctx.globalAlpha=1;ctx.strokeStyle='#5fd08a';ctx.strokeRect(0.5,0.5,c.width-1,c.height-1);
+};
+const stlFromBinary=buf=>{
+  const dv=new DataView(buf); const tris=dv.getUint32(80,true);
+  if(84+tris*50>buf.byteLength)throw new Error('Invalid binary STL');
+  const min=[Infinity,Infinity,Infinity],max=[-Infinity,-Infinity,-Infinity],out=[];
+  for(let i=0,p=84;i<tris;i++,p+=50){
+    const tri=[];
+    for(let v=0;v<3;v++){
+      const o=p+12+v*12;
+      const pt=[dv.getFloat32(o,true),dv.getFloat32(o+4,true),dv.getFloat32(o+8,true)];
+      tri.push(pt);
+      for(let a=0;a<3;a++){const n=pt[a]; if(n<min[a])min[a]=n; if(n>max[a])max[a]=n;}
+    }
+    out.push(tri);
+  }
+  return {min,max,tris:out};
+};
+const stlFromAscii=text=>{
+  const re=/vertex\s+([+-]?\d*\.?\d+(?:e[+-]?\d+)?)\s+([+-]?\d*\.?\d+(?:e[+-]?\d+)?)\s+([+-]?\d*\.?\d+(?:e[+-]?\d+)?)/ig;
+  const min=[Infinity,Infinity,Infinity],max=[-Infinity,-Infinity,-Infinity],verts=[],out=[]; let m,count=0;
+  while((m=re.exec(text))){
+    const pt=[parseFloat(m[1]),parseFloat(m[2]),parseFloat(m[3])]; verts.push(pt); count++;
+    for(let a=0;a<3;a++){const n=pt[a]; if(n<min[a])min[a]=n; if(n>max[a])max[a]=n;}
+    if(verts.length===3){out.push([verts[0],verts[1],verts[2]]);verts.length=0;}
+  }
+  if(!count)throw new Error('No STL vertices found');
+  return {min,max,tris:out};
+};
+const parseStl=buf=>{
+  try{return stlFromBinary(buf);}catch(e){}
+  return stlFromAscii(new TextDecoder().decode(buf));
+};
+const updateSlicerFit=()=>{
+  slicedZip=null;$('slicerUploadButton').disabled=true;$('slicerDownloadButton').disabled=true;show('slicerProgress',false);clearLayerPreview();drawModelPreview();
+  if(!slicerModel){setText('slicerScaleValue','100%');setText('slicerSize','-');setText('slicerScaledSize','-');slicerSetFit(false,'Load STL');$('slicerFitButton').disabled=true;$('slicerSliceButton').disabled=true;return;}
+  const scale=Math.max(1,Number($('slicerScale').value)||100)/100;
+  const d=slicerModel.dims, sx=d.x*scale, sy=d.y*scale, sz=d.z*scale;
+  const ok=sx<=BUILD.x&&sy<=BUILD.y&&sz<=BUILD.z;
+  setText('slicerScaleValue',Math.round(scale*100)+'%');
+  setText('slicerSize',fmtMm(d.x)+' x '+fmtMm(d.y)+' x '+fmtMm(d.z));
+  setText('slicerScaledSize',fmtMm(sx)+' x '+fmtMm(sy)+' x '+fmtMm(sz));
+  slicerSetFit(ok,ok?'Fits':'Too big');
+  $('slicerFitButton').disabled=ok;
+  $('slicerSliceButton').disabled=!ok;
+  $('slicerHint').textContent=ok?'Model fits TinyMaker. Ready to slice to ZIP.':'Model is larger than the TinyMaker build volume.';
+  drawModelPreview();
+};
+const loadSlicerFile=async file=>{
+  slicedZip=null;
+  if(!file){slicerModel=null;updateSlicerFit();return;}
+  $('slicerHint').textContent='Reading STL...';
+  try{
+    const b=parseStl(await file.arrayBuffer());
+    const dims={x:b.max[0]-b.min[0],y:b.max[1]-b.min[1],z:b.max[2]-b.min[2]};
+    slicerModel={name:file.name,bounds:b,dims};
+    $('slicerScale').value=100;
+    updateSlicerFit();
+  }catch(e){slicerModel=null;updateSlicerFit();$('slicerHint').textContent=e.message;}
+};
+const scaleSlicerToFit=()=>{
+  if(!slicerModel)return;
+  const d=slicerModel.dims;
+  const s=Math.min(BUILD.x/d.x,BUILD.y/d.y,BUILD.z/d.z,1);
+  const pct=Math.max(1,Math.floor(s*100));
+  if(pct<100&&!confirm('Model scaled to '+pct+'% to fit - continue?'))return;
+  $('slicerScale').value=pct;
+  updateSlicerFit();
+};
+const sleep=()=>new Promise(r=>setTimeout(r,0));
+const canvasBlob=(canvas,type)=>new Promise((res,rej)=>canvas.toBlob(b=>b?res(b):rej(new Error('PNG encode failed')),type));
+const safeZipName=name=>String(name||'model').replace(/\.[^.]+$/,'').replace(/[^A-Za-z0-9_-]+/g,'_')||'model';
+const transformPt=(p,scale)=>{
+  const b=slicerModel.bounds;
+  const cx=(b.min[0]+b.max[0])*0.5, cy=(b.min[1]+b.max[1])*0.5;
+  return {x:(p[0]-cx)*scale+BUILD.x*0.5,y:(p[1]-cy)*scale+BUILD.y*0.5,z:(p[2]-b.min[2])*scale};
+};
+const layerSegments=z=>{
+  const scale=Math.max(1,Number($('slicerScale').value)||100)/100, segs=[];
+  for(const tri of slicerModel.bounds.tris){
+    const pts=[transformPt(tri[0],scale),transformPt(tri[1],scale),transformPt(tri[2],scale)], hits=[];
+    for(let e=0;e<3;e++){
+      const a=pts[e],b=pts[(e+1)%3];
+      if((a.z<=z&&b.z>z)||(b.z<=z&&a.z>z)){
+        const t=(z-a.z)/(b.z-a.z);
+        hits.push({x:a.x+(b.x-a.x)*t,y:a.y+(b.y-a.y)*t});
+      }
+    }
+    if(hits.length===2)segs.push([hits[0],hits[1]]);
+  }
+  return segs;
+};
+const renderLayerPng=async z=>{
+  const canvas=document.createElement('canvas'); canvas.width=BUILD.px; canvas.height=BUILD.py;
+  const ctx=canvas.getContext('2d'), img=ctx.createImageData(BUILD.px,BUILD.py), data=img.data, segs=layerSegments(z);
+  for(let py=0;py<BUILD.py;py++){
+    const y=(py+0.5)/BUILD.py*BUILD.y, xs=[];
+    for(const s of segs){
+      const a=s[0],b=s[1];
+      if((a.y<=y&&b.y>y)||(b.y<=y&&a.y>y))xs.push(a.x+(y-a.y)*(b.x-a.x)/(b.y-a.y));
+    }
+    xs.sort((a,b)=>a-b);
+    for(let i=0;i+1<xs.length;i+=2){
+      const x1=Math.max(0,Math.min(BUILD.x,xs[i])), x2=Math.max(0,Math.min(BUILD.x,xs[i+1]));
+      let p1=Math.floor((BUILD.x-x2)/BUILD.x*BUILD.px), p2=Math.ceil((BUILD.x-x1)/BUILD.x*BUILD.px);
+      if(p1<0)p1=0;if(p2>BUILD.px)p2=BUILD.px;
+      for(let px=p1;px<p2;px++){const o=(py*BUILD.px+px)*4;data[o]=255;data[o+1]=255;data[o+2]=255;data[o+3]=255;}
+    }
+  }
+  ctx.putImageData(img,0,0);
+  return canvasBlob(canvas,'image/png');
+};
+const crcTable=(()=>{const t=[];for(let n=0;n<256;n++){let c=n;for(let k=0;k<8;k++)c=(c&1)?(0xedb88320^(c>>>1)):(c>>>1);t[n]=c>>>0;}return t;})();
+const crc32=buf=>{let c=0xffffffff;for(const b of buf)c=crcTable[(c^b)&255]^(c>>>8);return (c^0xffffffff)>>>0;};
+const u16=(a,v)=>{a.push(v&255,(v>>>8)&255);};
+const u32=(a,v)=>{a.push(v&255,(v>>>8)&255,(v>>>16)&255,(v>>>24)&255);};
+const makeZip=async files=>{
+  const encText=new TextEncoder(), chunks=[], central=[]; let offset=0;
+  for(const f of files){
+    const name=encText.encode(f.name), data=new Uint8Array(await f.blob.arrayBuffer()), crc=crc32(data), local=[];
+    u32(local,0x04034b50);u16(local,20);u16(local,0);u16(local,0);u16(local,0);u16(local,0);u32(local,crc);u32(local,data.length);u32(local,data.length);u16(local,name.length);u16(local,0);
+    chunks.push(new Uint8Array(local),name,data);
+    const cen=[];u32(cen,0x02014b50);u16(cen,20);u16(cen,20);u16(cen,0);u16(cen,0);u16(cen,0);u16(cen,0);u32(cen,crc);u32(cen,data.length);u32(cen,data.length);u16(cen,name.length);u16(cen,0);u16(cen,0);u16(cen,0);u16(cen,0);u32(cen,0);u32(cen,offset);
+    central.push(new Uint8Array(cen),name); offset+=local.length+name.length+data.length;
+  }
+  const centralSize=central.reduce((n,c)=>n+c.length,0), end=[];u32(end,0x06054b50);u16(end,0);u16(end,0);u16(end,files.length);u16(end,files.length);u32(end,centralSize);u32(end,offset);u16(end,0);
+  return new Blob([...chunks,...central,new Uint8Array(end)],{type:'application/zip'});
+};
+const showLayerPreview=idx=>{
+  if(!slicedZip||!slicedZip.layers||!slicedZip.layers.length)return;
+  const layer=Math.max(1,Math.min(slicedZip.layers.length,idx||1));
+  const c=$('layerPreviewCanvas'),ctx=c.getContext('2d'),img=new Image(),url=URL.createObjectURL(slicedZip.layers[layer-1]);
+  $('layerPreviewRange').value=layer;
+  $('layerPreviewLabel').textContent=layer+' / '+slicedZip.layers.length;
+  img.onload=()=>{ctx.fillStyle='#111';ctx.fillRect(0,0,c.width,c.height);ctx.drawImage(img,0,0,c.width,c.height);URL.revokeObjectURL(url);};
+  img.onerror=()=>URL.revokeObjectURL(url);
+  img.src=url;
+};
+const enableLayerPreview=layers=>{
+  $('layerPreviewRange').min=1;
+  $('layerPreviewRange').max=layers.length;
+  const mid=Math.max(1,Math.ceil(layers.length/2));
+  show('layerPreviewBox',true);
+  showLayerPreview(mid);
+};
+const sliceToZip=async()=>{
+  if(!slicerModel)return;
+  const scale=Math.max(1,Number($('slicerScale').value)||100)/100, height=slicerModel.dims.z*scale, lh=Number($('cfgLayerHeight').value)||0.05, layers=Math.max(1,Math.ceil(height/lh));
+  if(layers>1200&&!confirm('This will create '+layers+' layers. Continue?'))return;
+  $('slicerSliceButton').disabled=true;$('slicerUploadButton').disabled=true;$('slicerDownloadButton').disabled=true;show('slicerProgress',true);
+  const files=[];
+  try{
+    for(let i=1;i<=layers;i++){
+      $('slicerHint').textContent='Slicing layer '+i+' / '+layers+'...';
+      files.push({name:i+'.png',blob:await renderLayerPng((i-0.5)*lh)});
+      if(i%4===0)await sleep();
+    }
+    $('slicerHint').textContent='Packaging ZIP...';
+    const blob=await makeZip(files), name=safeZipName(slicerModel.name)+'.zip';
+    slicedZip={blob,name,layers:files.map(f=>f.blob)};
+    $('slicerUploadButton').disabled=false;
+    $('slicerDownloadButton').disabled=false;
+    enableLayerPreview(slicedZip.layers);
+    $('slicerHint').textContent='ZIP ready: '+name+' ('+Math.ceil(blob.size/1024)+' KB).';
+  }catch(e){$('slicerHint').textContent=e.message;}
+  finally{$('slicerSliceButton').disabled=false;show('slicerProgress',false);}
+};
+const downloadSlicedZip=()=>{
+  if(!slicedZip)return;
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(slicedZip.blob);
+  a.download=slicedZip.name;
+  a.click();
+  setTimeout(()=>URL.revokeObjectURL(a.href),10000);
+};
+const uploadSlicedZip=async()=>{
+  if(!slicedZip)return;
+  if(!checkUploadFits(slicedZip.blob.size,$('slicerHint')))return;
+  const fd=new FormData();fd.append('file',new File([slicedZip.blob],slicedZip.name,{type:'application/zip'}));
+  $('slicerUploadButton').disabled=true;$('slicerHint').textContent='Uploading sliced ZIP...';
+  const started=Date.now();
+  try{await uploadWithProgress(fd,$('slicerHint'));$('slicerHint').textContent='Upload complete in '+formatShortTime(Date.now()-started)+'.';openView('home');loadFiles();}
+  catch(e){$('slicerHint').textContent=e.message;$('slicerUploadButton').disabled=false;}
+};
 
 const setConfigDisabled=disabled=>{document.querySelectorAll('#configForm input,#configForm button,#configDefaultsButton,#configMqttResetButton').forEach(e=>e.disabled=disabled);};
+const configIsLocallyLocked=()=>!!(statusData&&statusData.busy);
 const updateMqttFields=()=>show('mqttFields',$('cfgMqttEnabled').checked);
 const loadConfig=async()=>{
   try{
     const c=await api('/api/config');
     $('cfgLayerHeight').value=Number(c.layerHeight).toFixed(2); $('cfgBaseExposure').value=c.baseExposure; $('cfgRegularExposure').value=c.regularExposure; $('cfgBaseLayers').value=c.baseLayers; $('cfgTransitionLayers').value=c.transitionLayers;
-    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun;
+    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun; $('cfgExperimentalSlicing').checked=!!c.experimentalSlicing;
+    slicingEnabled=!!c.experimentalSlicing;show('slicerViewButton',slicingEnabled);if(!slicingEnabled&&!$('slicerView').classList.contains('hidden'))openView('home');
     $('cfgMqttEnabled').checked=!!c.mqttEnabled; $('cfgMqttHost').value=c.mqttHost||''; $('cfgMqttPort').value=c.mqttPort||1883; $('cfgMqttUser').value=c.mqttUser||''; $('cfgMqttPassword').value=''; $('cfgMqttTopic').value=c.mqttTopic||'TinyMaker';
     $('mqttHint').textContent=c.mqttPasswordSet?'Password is saved. Enter a new one only if you want to replace it.':'MQTT password is not set.';
     updateMqttFields();
     show('configMqttResetButton',!!c.mqttConfigured);
     $('configDefaultsButton').textContent=c.mqttConfigured?'Reset to defaults (Excluding MQTT)':'Reset to defaults';
-    setConfigDisabled(!!c.locked); $('configHint').textContent=c.locked?'Config is locked while printing.':'Config locks automatically while printing.';
-  }catch(e){$('configHint').textContent=e.message;}
+    const locked=!!c.locked||configIsLocallyLocked();
+    setConfigDisabled(locked); $('configHint').textContent=locked?'Config is locked while printing.':'Config locks automatically while printing.';
+  }catch(e){const locked=configIsLocallyLocked();setConfigDisabled(locked);$('configHint').textContent=locked?'Config is locked while printing.':e.message;}
 };
 
 window.modelDetails=modelDetails;
 window.startPrint=startPrint;
 window.deleteFile=deleteFile;
 
-$('uploadForm').addEventListener('submit',async e=>{e.preventDefault();const f=$('uploadFile').files[0];if(!f)return;const fd=new FormData();fd.append('file',f);$('uploadButton').disabled=true;$('uploadHint').textContent='Uploading...';try{await api('/upload',{method:'POST',body:fd});$('uploadFile').value='';$('uploadHint').textContent='Upload complete.';loadFiles();}catch(err){$('uploadHint').textContent=err.message;}finally{$('uploadButton').disabled=false;}});
+$('uploadForm').addEventListener('submit',async e=>{e.preventDefault();const f=$('uploadFile').files[0];if(!f)return;if(!checkUploadFits(f.size,$('uploadHint')))return;const fd=new FormData();fd.append('file',f);$('uploadButton').disabled=true;$('uploadHint').textContent='Uploading...';const started=Date.now();try{await uploadWithProgress(fd,$('uploadHint'));$('uploadFile').value='';$('uploadHint').textContent='Upload complete in '+formatShortTime(Date.now()-started)+'.';loadFiles();}catch(err){$('uploadHint').textContent=err.message;}finally{$('uploadButton').disabled=false;}});
 $('configForm').addEventListener('submit',async e=>{e.preventDefault();try{await api('/api/config',{method:'POST',body:new FormData(e.target)});msg('Config saved.');loadConfig();}catch(err){msg(err.message,true);}});
 $('configDefaultsButton').addEventListener('click',async()=>{const keep=$('configDefaultsButton').textContent.indexOf('MQTT')>=0;if(!confirm(keep?'Reset config to defaults and keep MQTT settings?':'Reset config to defaults?'))return;try{await api('/api/config/defaults',{method:'POST'});msg(keep?'Defaults restored. MQTT settings kept.':'Defaults restored.');loadConfig();}catch(e){msg(e.message,true);}});
 $('configMqttResetButton').addEventListener('click',async()=>{if(!confirm('Reset MQTT settings?'))return;try{await api('/api/config/mqtt/defaults',{method:'POST'});msg('MQTT settings reset.');loadConfig();}catch(e){msg(e.message,true);}});
 $('disableDryRunButton').addEventListener('click',async()=>{if(!confirm('Disable dry run mode? Future prints will use the UV LEDs.'))return;try{await api('/api/config/dry-run?enabled=0',{method:'POST'});msg('Dry run disabled.');loadConfig();refreshStatus();}catch(e){msg(e.message,true);}});
 $('cfgMqttEnabled').addEventListener('change',updateMqttFields);
 $('homeViewButton').addEventListener('click',()=>openView('home'));
+$('slicerViewButton').addEventListener('click',()=>openView('slicer'));
 $('configViewButton').addEventListener('click',()=>openView('config'));
 $('modelBackButton').addEventListener('click',()=>openView('home'));
+$('slicerBackButton').addEventListener('click',()=>openView('home'));
 $('configBackButton').addEventListener('click',()=>openView('home'));
 $('pauseButton').addEventListener('click',()=>printCommand('pause','Pause this print?'));
 $('resumeButton').addEventListener('click',()=>printCommand('resume','Resume this print?'));
 $('stopButton').addEventListener('click',()=>printCommand('stop','Stop this print?'));
 $('modelMlButton').addEventListener('click',()=>modelDetails(enc(selectedModel),true));
 $('modelStartButton').addEventListener('click',()=>startPrint(enc(selectedModel)));
+$('slicerFile').addEventListener('change',e=>loadSlicerFile(e.target.files[0]));
+$('slicerScale').addEventListener('input',updateSlicerFit);
+$('slicerFitButton').addEventListener('click',scaleSlicerToFit);
+$('slicerSliceButton').addEventListener('click',sliceToZip);
+$('slicerDownloadButton').addEventListener('click',downloadSlicedZip);
+$('slicerUploadButton').addEventListener('click',uploadSlicedZip);
+$('layerPreviewRange').addEventListener('input',e=>showLayerPreview(Number(e.target.value)));
 
-openView('home');refreshStatus();loadConfig();setInterval(refreshStatus,2000);
+drawModelPreview();clearLayerPreview();openView('home');refreshStatus();loadConfig();setInterval(tickLocalStatus,1000);setInterval(()=>{refreshStatus();retryPendingPrintCommand();},2000);
 </script>
 )SPA";
-  inner.replace("{{FW}}", fw);
-  server.send(200, "text/html", rootStyledPage(inner));
+  sendRootStyledPage(rootBodyBeforeFw, fw, rootBodyAfterFw);
 }
 
 // ===================================================================================
@@ -1779,6 +2262,14 @@ void network_loop() {
     badgeTs = millis();
     drawWifiBadge();
   }
+}
+
+void network_service_window(uint16_t durationMs) {
+  unsigned long until = millis() + durationMs;
+  do {
+    network_loop();
+    delay(1);
+  } while ((long)(until - millis()) > 0);
 }
 
 // ===================================================================================

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -59,7 +59,17 @@ File uploadFile;
 String uploadPath;      // e.g. "/Benchy.sl1"
 String modelName;       // e.g. "Benchy"
 bool uploadOk = false;
+bool uploadRejected = false;
 unsigned long otaShownBytes = 0;   // progress counter (upload + web OTA)
+
+extern unsigned long whitePixelsAccum;
+extern bool countPixelsMode;
+extern bool estimateCancelReq;
+void *myOpen(const char *filename, int32_t *size);
+void myClose(void *handle);
+int32_t myRead(PNGFILE *handle, uint8_t *buffer, int32_t length);
+int32_t mySeek(PNGFILE *handle, int32_t position);
+void PNGDraw(PNGDRAW *pDraw);
 
 // The ZIP/SL1 conversion pipeline (zip callbacks, layerIndexFromEntry,
 // safeModelName, unpackModel) lives in Import.ino - outside the network
@@ -70,6 +80,21 @@ unsigned long otaShownBytes = 0;   // progress counter (upload + web OTA)
 // HTTP upload handlers
 // ===================================================================================
 
+bool sdCardReady() {
+  File cardRoot = SD.open("/");
+  if (cardRoot) {
+    cardRoot.close();
+    return true;
+  }
+
+  if (!SD.begin(SDCS, SD_SCK_MHZ(16))) return false;
+
+  cardRoot = SD.open("/");
+  if (!cardRoot) return false;
+  cardRoot.close();
+  return true;
+}
+
 // Streaming part - called repeatedly with chunks of the multipart body
 void handleUploadData() {
   HTTPUpload &up = server.upload();
@@ -78,9 +103,31 @@ void handleUploadData() {
     modelName = safeModelName(up.filename);
     uploadPath = "/" + modelName + ".zip";
     uploadOk = false;
+    uploadRejected = false;
     otaShownBytes = 0;
+
+    if (printerBusy()) {
+      uploadRejected = true;
+      DBGLN("Upload rejected: printer busy");
+      return;
+    }
+
+    if (!sdCardReady()) {
+      uploadRejected = true;
+      DBGLN("Upload rejected: SD card unavailable");
+      netMessage("Upload blocked", "No SD card");
+      return;
+    }
+
     SD.remove(uploadPath.c_str());
     uploadFile = SD.open(uploadPath.c_str(), FILE_WRITE);
+    if (!uploadFile) {
+      uploadRejected = true;
+      DBGLN("Upload rejected: cannot open SD file");
+      netMessage("Upload blocked", "SD write failed");
+      return;
+    }
+
     DBG("Upload start: %s\n", uploadPath.c_str());
     // Same style as WiFi/delete/OTA: title + a sweeping progress bar.
     // Multipart uploads don't announce total size, so the bar animates by
@@ -88,6 +135,7 @@ void handleUploadData() {
     netProgressStart("Receiving model:", modelName.c_str());
   }
   else if (up.status == UPLOAD_FILE_WRITE) {
+    if (uploadRejected) return;
     if (uploadFile) uploadFile.write(up.buf, up.currentSize);
     if (up.totalSize - otaShownBytes >= 65536) { // redraw every 64 KB
       otaShownBytes = up.totalSize;
@@ -97,6 +145,7 @@ void handleUploadData() {
     }
   }
   else if (up.status == UPLOAD_FILE_END) {
+    if (uploadRejected) return;
     if (uploadFile) { uploadFile.close(); uploadOk = true; }
     DBG("Upload done: %u bytes\n", up.totalSize);
   }
@@ -108,6 +157,21 @@ void handleUploadData() {
 
 // Final part - runs once after the whole request body is received
 void finishUpload() {
+  if (uploadRejected) {
+    uploadRejected = false;
+    uploadOk = false;
+    if (printerBusy()) {
+      server.send(409, "application/json", "{\"error\":\"printer busy\"}");
+      return;
+    } else {
+      server.send(503, "application/json", "{\"error\":\"sd card unavailable\"}");
+      netMessage("Upload blocked", "No SD card");
+    }
+    delay(1500);
+    screen1();
+    return;
+  }
+
   bool ok = false;
   if (uploadOk) {
     String dest = "/" + modelName;
@@ -270,6 +334,933 @@ void handleUpdateFinish() {
     delay(1500);
     screen1();
   }
+}
+
+// ===================================================================================
+// Root page: small device dashboard at http://tinymaker.local/
+// ===================================================================================
+
+String printerStateText() {
+  if (screen == 1111 || screen == 1112 || screen == 11111 || screen == 11112 || screen == 11113) {
+    String prefix = uvLedEnabled ? "" : "Testing - ";
+    switch (current_state) {
+      case 0: return prefix + "Homing";
+      case 1: return uvLedEnabled ? "Curing" : "Testing";
+      case 2: return prefix + "Lifting";
+      case 3: return prefix + "Dropping";
+      case 4: return prefix + "Canceling";
+      case 5: return prefix + "Pausing";
+      case 6: return prefix + "Paused";
+      case 7: return prefix + "Resuming";
+      case 8: return prefix + "Finished";
+      default: return uvLedEnabled ? "Printing" : "Testing";
+    }
+  }
+  return "Idle";
+}
+
+String jsonEscape(String s) {
+  s.replace("\\", "\\\\");
+  s.replace("\"", "\\\"");
+  s.replace("\n", "\\n");
+  s.replace("\r", "\\r");
+  return s;
+}
+
+String formatDuration(uint32_t secs) {
+  uint32_t hours = secs / 3600UL;
+  uint8_t minutes = (secs % 3600UL) / 60UL;
+  uint8_t seconds = secs % 60UL;
+  String out;
+  if (hours > 0) {
+    out += String(hours);
+    out += "h ";
+  }
+  out += String(minutes);
+  out += "m";
+  if (hours == 0) {
+    out += " ";
+    out += String(seconds);
+    out += "s";
+  }
+  return out;
+}
+
+uint32_t currentRunSecs() {
+  if (!printerBusy() || printStartMs == 0) return 0;
+  return (millis() - printStartMs) / 1000UL;
+}
+
+uint32_t remainingPrintSecs() {
+  if (!printerBusy() || layer_counter <= 0) return 0;
+  long layersLeft = layer_counter - current_layer;
+  if (layersLeft < 0) layersLeft = 0;
+
+  uint32_t secs = 0;
+  if (current_layer < Base_Layer) {
+    secs += (Base_Layer - current_layer) * Base_Exposure;
+  }
+  secs += layersLeft * Regular_Exposure;
+  if (layersLeft > 1) {
+    secs += (uint32_t)((layersLeft - 1) * motor_updown_time);
+  }
+  return secs;
+}
+
+bool modelPngExists(const String &name, int index) {
+  String path = "/" + name + "/" + String(index) + ".png";
+  File entry = SD.open(path.c_str());
+  bool exists = (bool)entry;
+  if (entry) entry.close();
+  return exists;
+}
+
+int countModelSourceLayers(const String &name) {
+  int count = 0;
+  while (modelPngExists(name, count + 100)) count += 100;
+  while (modelPngExists(name, count + 1)) count++;
+  return count;
+}
+
+bool modelStats(const String &name, int &printLayers, float &heightMm, uint32_t &timeSecs) {
+  int sourceLayers = countModelSourceLayers(name);
+  if (sourceLayers <= 0 || sourceLayers > MAX_LAYER_FILES) return false;
+
+  get_motor_updown_time();
+  printLayers = sourceLayers;
+  if (Layer_Height < 0.09) {
+    heightMm = sourceLayers * 0.05;
+  }
+  if (Layer_Height > 0.06) {
+    printLayers = sourceLayers / 2;
+    heightMm = 0.1 * printLayers;
+  }
+
+  long exposureLayers = printLayers - Base_Layer;
+  if (exposureLayers < 0) exposureLayers = 0;
+  long movementLayers = printLayers - 1;
+  if (movementLayers < 0) movementLayers = 0;
+  timeSecs = (Base_Layer * Base_Exposure) +
+             (exposureLayers * Regular_Exposure) +
+             (uint32_t)(motor_updown_time * movementLayers);
+  return true;
+}
+
+bool estimateModelResin(const String &name, int printLayers, double &ml) {
+  if (printLayers <= 0) return false;
+
+  double volMm3 = 0.0;
+  countPixelsMode = true;
+  estimateCancelReq = false;
+
+  for (int layer = 1; layer <= printLayers; layer++) {
+    int idx = layer;
+    if (Layer_Height > 0.06) idx = layer * 2 - 1;
+    String fn = "/" + name + "/" + String(idx) + ".png";
+    char nc[120];
+    fn.toCharArray(nc, sizeof(nc));
+    whitePixelsAccum = 0;
+    if (png.open((const char *)nc, myOpen, myClose, myRead, mySeek, PNGDraw) == PNG_SUCCESS) {
+      png.decode(NULL, 0);
+      png.close();
+    }
+    volMm3 += (double)whitePixelsAccum * 0.01626 * Layer_Height;
+  }
+
+  countPixelsMode = false;
+  ml = volMm3 / 1000.0;
+  return true;
+}
+
+long formLong(const char *name, long fallback, long minVal, long maxVal) {
+  if (!server.hasArg(name)) return fallback;
+  long v = server.arg(name).toInt();
+  if (v < minVal) return minVal;
+  if (v > maxVal) return maxVal;
+  return v;
+}
+
+void sendApiError(int code, const char *message) {
+  String out = "{\"ok\":false,\"error\":\"";
+  out += jsonEscape(message);
+  out += "\"}";
+  server.send(code, "application/json", out);
+}
+
+void sendApiOk(const String &extra) {
+  String out = "{\"ok\":true";
+  if (extra.length() > 0) {
+    out += ",";
+    out += extra;
+  }
+  out += "}";
+  server.send(200, "application/json", out);
+}
+
+bool safeRootName(const String &name) {
+  if (name.length() == 0 || name.length() > 100) return false;
+  if (name == "." || name == "..") return false;
+  return name.indexOf('/') < 0 && name.indexOf('\\') < 0;
+}
+
+bool rootEntryManaged(const String &name, bool isDir) {
+  if (!safeRootName(name)) return false;
+  if (isDir) {
+    File probe = SD.open(("/" + name + "/1.png").c_str());
+    if (!probe) return false;
+    probe.close();
+    return true;
+  }
+  String lower = name;
+  lower.toLowerCase();
+  return lower.endsWith(".sl1") || lower.endsWith(".zip");
+}
+
+String rootStyledPage(const String &inner);
+
+bool validPrintableModel(const String &name) {
+  if (!safeRootName(name)) return false;
+  File entry = SD.open(("/" + name).c_str());
+  if (!entry) return false;
+  bool isDir = entry.isDirectory();
+  entry.close();
+  return isDir && rootEntryManaged(name, true);
+}
+
+void handleApiFiles() {
+  if (printerBusy()) {
+    sendApiError(409, "printer busy");
+    return;
+  }
+  if (!sdCardReady()) {
+    sendApiError(503, "sd card unavailable");
+    return;
+  }
+
+  File dir = SD.open("/");
+  if (!dir) {
+    sendApiError(503, "sd card unavailable");
+    return;
+  }
+
+  String out = "{\"ok\":true,\"sdReady\":true,\"items\":[";
+  bool first = true;
+  int shown = 0;
+  int skipped = 0;
+  while (true) {
+    File entry = dir.openNextFile();
+    if (!entry) break;
+
+    char rawName[101];
+    entry.getName(rawName, sizeof(rawName));
+    String name = String(rawName);
+    bool isDir = entry.isDirectory();
+    uint32_t bytes = isDir ? 0 : entry.size();
+    entry.close();
+
+    if (!rootEntryManaged(name, isDir)) {
+      skipped++;
+      continue;
+    }
+    if (shown >= 64) {
+      skipped++;
+      continue;
+    }
+
+    if (!first) out += ",";
+    first = false;
+    out += "{\"name\":\"";
+    out += jsonEscape(name);
+    out += "\",\"type\":\"";
+    out += isDir ? "model" : "archive";
+    out += "\",\"printable\":";
+    out += isDir ? "true" : "false";
+    out += ",\"sizeBytes\":";
+    out += String(bytes);
+    out += "}";
+    shown++;
+  }
+  dir.close();
+
+  out += "],\"hiddenCount\":";
+  out += String(skipped);
+  out += "}";
+  server.send(200, "application/json", out);
+}
+
+void handleApiFileModel() {
+  if (printerBusy()) {
+    sendApiError(409, "printer busy");
+    return;
+  }
+  if (!sdCardReady()) {
+    sendApiError(503, "sd card unavailable");
+    return;
+  }
+
+  String name = server.arg("name");
+  if (!validPrintableModel(name)) {
+    sendApiError(404, "model not found");
+    return;
+  }
+
+  int printLayers = 0;
+  float heightMm = 0;
+  uint32_t timeSecs = 0;
+  if (!modelStats(name, printLayers, heightMm, timeSecs)) {
+    sendApiError(400, "model is not printable");
+    return;
+  }
+
+  String out = "{\"ok\":true,\"name\":\"";
+  out += jsonEscape(name);
+  out += "\",\"layers\":";
+  out += String(printLayers);
+  out += ",\"heightMm\":";
+  out += String(heightMm, 2);
+  out += ",\"estimatedSecs\":";
+  out += String(timeSecs);
+  out += ",\"estimatedTime\":\"";
+  out += formatDuration(timeSecs);
+  out += "\"";
+
+  if (server.hasArg("estimate")) {
+    double ml = 0;
+    bool ok = estimateModelResin(name, printLayers, ml);
+    out += ",\"resinEstimated\":";
+    out += ok ? "true" : "false";
+    if (ok) {
+      out += ",\"resinMl\":";
+      out += String(ml, 1);
+    }
+  }
+
+  out += "}";
+  server.send(200, "application/json", out);
+}
+
+bool deleteSdItem(const String &requestedName, String &error) {
+  if (printerBusy()) {
+    error = "printer busy";
+    return false;
+  }
+
+  if (!sdCardReady()) {
+    error = "sd card unavailable";
+    return false;
+  }
+
+  String name = requestedName;
+  if (!safeRootName(name)) {
+    error = "invalid sd item";
+    return false;
+  }
+
+  String path = "/" + name;
+  File entry = SD.open(path.c_str());
+  if (!entry) {
+    error = "sd item not found";
+    return false;
+  }
+  bool isDir = entry.isDirectory();
+  entry.close();
+
+  if (!rootEntryManaged(name, isDir)) {
+    error = "unsupported sd item";
+    return false;
+  }
+
+  bool ok = isDir ? deleteModelFolder(path.c_str()) : SD.remove(path.c_str());
+  if (!ok) {
+    error = "delete failed";
+    return false;
+  }
+
+  return true;
+}
+
+void handleApiFileDelete() {
+  String error;
+  if (!deleteSdItem(server.arg("name"), error)) {
+    int code = 400;
+    if (error == "printer busy") code = 409;
+    if (error == "sd card unavailable") code = 503;
+    if (error == "sd item not found") code = 404;
+    if (error == "delete failed") code = 500;
+    sendApiError(code, error.c_str());
+    return;
+  }
+
+  sendApiOk("\"deleted\":true");
+}
+
+bool queueModelPrint(const String &requestedName, String &error) {
+  if (printerBusy()) {
+    error = "printer busy";
+    return false;
+  }
+  if (!sdCardReady()) {
+    error = "sd card unavailable";
+    return false;
+  }
+
+  String name = requestedName;
+  if (!safeRootName(name)) {
+    error = "invalid model";
+    return false;
+  }
+
+  String path = "/" + name;
+  File entry = SD.open(path.c_str());
+  if (!entry) {
+    error = "model not found";
+    return false;
+  }
+  bool isDir = entry.isDirectory();
+  entry.close();
+
+  if (!isDir || !rootEntryManaged(name, true)) {
+    error = "only printable model folders can be started";
+    return false;
+  }
+
+  name.toCharArray(foldersel_long, sizeof(foldersel_long));
+  foldersel = name;
+  selIsArchive = false;
+  root = SD.open("/");
+
+  if (!prepareSelectedPrintPreview()) {
+    delay(1000);
+    screen1();
+    error = "model is not printable";
+    return false;
+  }
+
+  webStartPrint = true;
+  return true;
+}
+
+String configJson() {
+  String out = "\"locked\":";
+  out += printerBusy() ? "true" : "false";
+  out += ",\"layerHeight\":";
+  out += String(Layer_Height, 2);
+  out += ",\"baseExposure\":";
+  out += String(Base_Exposure);
+  out += ",\"regularExposure\":";
+  out += String(Regular_Exposure);
+  out += ",\"baseLayers\":";
+  out += String(Base_Layer);
+  out += ",\"transitionLayers\":";
+  out += String(Transition_Layer);
+  out += ",\"slowLiftDistance\":";
+  out += String(Slow_Lift_Distance);
+  out += ",\"fastLiftDistance\":";
+  out += String(Fast_Lift_Distance);
+  out += ",\"slowLiftFeedrate\":";
+  out += String(Slow_Lift_Feedrate);
+  out += ",\"fastLiftFeedrate\":";
+  out += String(Fast_Lift_Feedrate);
+  out += ",\"dropBackFeedrate\":";
+  out += String(Drop_Back_Feedrate);
+  out += ",\"uiTimeoutSecs\":";
+  out += String(uiTimeoutSecs);
+  out += ",\"dryRun\":";
+  out += uvLedEnabled ? "false" : "true";
+  out += ",\"uvLedEnabled\":";
+  out += uvLedEnabled ? "true" : "false";
+  return out;
+}
+
+void applyConfigRequest() {
+  float requestedLayer = server.hasArg("layer_height") ? server.arg("layer_height").toFloat() : Layer_Height;
+  Layer_Height = requestedLayer < 0.075 ? 0.05 : 0.10;
+  Base_Exposure = formLong("base_exposure", Base_Exposure, 10, 60);
+  Regular_Exposure = formLong("regular_exposure", Regular_Exposure, 1, 30);
+  Base_Layer = formLong("base_layer", Base_Layer, 1, 8);
+  Transition_Layer = formLong("transition_layer", Transition_Layer, 0, 10);
+  Slow_Lift_Distance = formLong("slow_lift_distance", Slow_Lift_Distance, 1, 3);
+  Fast_Lift_Distance = formLong("fast_lift_distance", Fast_Lift_Distance, 1, 3);
+  Slow_Lift_Feedrate = formLong("slow_lift_feedrate", Slow_Lift_Feedrate, 20, 50);
+  Fast_Lift_Feedrate = formLong("fast_lift_feedrate", Fast_Lift_Feedrate, 20, 50);
+  Drop_Back_Feedrate = formLong("drop_back_feedrate", Drop_Back_Feedrate, 20, 50);
+  uiTimeoutSecs = formLong("ui_timeout", uiTimeoutSecs, 0, 3600);
+  uvLedEnabled = !server.hasArg("dry_run");
+
+  savePrintSettings();
+  saveDeviceConfig();
+}
+
+void handleApiConfigGet() {
+  sendApiOk(configJson());
+}
+
+void handleApiConfigSave() {
+  if (printerBusy()) {
+    sendApiError(409, "printer busy");
+    return;
+  }
+
+  applyConfigRequest();
+  sendApiOk(configJson());
+}
+
+void resetWebConfigToDefaults() {
+  resetSettingsToDefault();
+  uiTimeoutSecs = 0;
+  uvLedEnabled = true;
+  saveDeviceConfig();
+}
+
+void handleApiConfigDefaults() {
+  if (printerBusy()) {
+    sendApiError(409, "printer busy");
+    return;
+  }
+
+  resetWebConfigToDefaults();
+  sendApiOk(configJson());
+}
+
+void handleApiConfigDryRun() {
+  if (printerBusy()) {
+    sendApiError(409, "printer busy");
+    return;
+  }
+
+  bool enabled = server.hasArg("enabled") &&
+                 server.arg("enabled") != "0" &&
+                 server.arg("enabled") != "false";
+  uvLedEnabled = !enabled;
+  saveDeviceConfig();
+  sendApiOk(configJson());
+}
+
+bool requestPrintPause(String &error) {
+  if (!printerBusy()) {
+    error = "printer is not printing";
+    return false;
+  }
+  if (current_state == 5) {
+    return true;
+  }
+  if (print_paused || current_state == 0 || current_state == 4 || current_state == 6 ||
+      current_state == 7 || current_state == 8) {
+    error = "pause is not available in this state";
+    return false;
+  }
+
+  screen1111();
+  current_state = 5;
+  screen1111_state();
+  screen1112();
+  gfx2->fillRect(136, 12, 16, 16, 0x8410);
+  gfx2->fillTriangle(136, 52, 136, 68, 152, 60, 0x8410);
+  gfx2->drawRoundRect(128, 44, 32, 32, 3, 0x8410);
+  print_paused = true;
+  return true;
+}
+
+bool requestPrintResume(String &error) {
+  if (!printerBusy() || current_state != 6) {
+    error = "printer is not paused";
+    return false;
+  }
+
+  current_state = 7;
+  screen1111_state();
+  webResumePrint = true;
+  return true;
+}
+
+bool requestPrintStop(String &error) {
+  if (!printerBusy()) {
+    error = "printer is not printing";
+    return false;
+  }
+  if (current_state == 4) {
+    error = "printer is already stopping";
+    return false;
+  }
+
+  bool wasHoming = current_state == 0;
+  digitalWrite(LED, LOW);
+  screen1111();
+  current_state = 4;
+  screen1111_state();
+  gfx2->fillRect(136, 12, 16, 16, 0x8410);
+  gfx2->fillRect(136, 52, 6, 16, 0x8410);
+  gfx2->fillRect(146, 52, 6, 16, 0x8410);
+  gfx2->drawRoundRect(128, 4, 32, 32, 3, 0x8410);
+  print_canceled = true;
+  print_paused = false;
+  webResumePrint = false;
+  if (wasHoming) homing_canceled = true;
+  return true;
+}
+
+void handleApiPrintStart() {
+  String error;
+  if (!queueModelPrint(server.arg("name"), error)) {
+    int code = 400;
+    if (error == "printer busy") code = 409;
+    if (error == "sd card unavailable") code = 503;
+    if (error == "model not found") code = 404;
+    sendApiError(code, error.c_str());
+    return;
+  }
+
+  sendApiOk("\"queued\":true");
+}
+
+void handleApiPrintPause() {
+  String error;
+  if (!requestPrintPause(error)) {
+    sendApiError(409, error.c_str());
+    return;
+  }
+
+  sendApiOk("\"paused\":true");
+}
+
+void handleApiPrintResume() {
+  String error;
+  if (!requestPrintResume(error)) {
+    sendApiError(409, error.c_str());
+    return;
+  }
+
+  sendApiOk("\"resumeQueued\":true");
+}
+
+void handleApiPrintStop() {
+  String error;
+  if (!requestPrintStop(error)) {
+    sendApiError(409, error.c_str());
+    return;
+  }
+
+  sendApiOk("\"stopping\":true");
+}
+
+void handleApiStatus() {
+  bool busy = printerBusy();
+  bool connected = WiFi.status() == WL_CONNECTED;
+  bool sdReady = busy ? false : sdCardReady();
+
+  String out = "{";
+  out += "\"busy\":";
+  out += busy ? "true" : "false";
+  out += ",\"paused\":";
+  out += print_paused ? "true" : "false";
+  out += ",\"pausing\":";
+  out += current_state == 5 ? "true" : "false";
+  out += ",\"resuming\":";
+  out += current_state == 7 ? "true" : "false";
+  out += ",\"stopping\":";
+  out += current_state == 4 ? "true" : "false";
+  out += ",\"dryRun\":";
+  out += uvLedEnabled ? "false" : "true";
+  out += ",\"canPause\":";
+  out += (busy && !print_paused && current_state >= 1 && current_state <= 3) ? "true" : "false";
+  out += ",\"canResume\":";
+  out += current_state == 6 ? "true" : "false";
+  out += ",\"canStop\":";
+  out += (busy && current_state != 4 && current_state != 8) ? "true" : "false";
+  out += ",\"state\":\"";
+  out += jsonEscape(printerStateText());
+  out += "\",\"stateCode\":";
+  out += String(current_state);
+  out += ",\"wifiRssi\":";
+  out += connected ? String(WiFi.RSSI()) : String(0);
+  out += ",\"wifiText\":\"";
+  out += connected ? String(WiFi.RSSI()) + " dBm" : String("Offline");
+  out += "\",\"ip\":\"";
+  out += connected ? WiFi.localIP().toString() : String("-");
+  out += "\",\"sdReady\":";
+  out += sdReady ? "true" : "false";
+  out += ",\"sdText\":\"";
+  out += busy ? String("Locked") : (sdReady ? String("Ready") : String("Missing"));
+  out += "\",\"lifetimePrintSecs\":";
+  out += String(totalPrintSecs);
+  out += ",\"lifetimePrintTime\":\"";
+  out += formatDuration(totalPrintSecs);
+  out += "\",\"currentLayer\":";
+  out += String(current_layer);
+  out += ",\"totalLayers\":";
+  out += String(layer_counter);
+  out += ",\"layerText\":\"";
+  out += String(current_layer) + " / " + String(layer_counter);
+  out += "\",\"resinUsedMl\":";
+  out += String(resinUsedMl, 1);
+  out += ",\"resinText\":\"";
+  out += String(resinUsedMl, 1) + " ml";
+  out += "\",\"runSecs\":";
+  out += String(currentRunSecs());
+  out += ",\"runTime\":\"";
+  out += formatDuration(currentRunSecs());
+  out += "\",\"remainingSecs\":";
+  out += String(remainingPrintSecs());
+  out += ",\"remainingTime\":\"";
+  out += formatDuration(remainingPrintSecs());
+  out += "\"}";
+
+  server.send(200, "application/json", out);
+}
+
+String rootStyledPage(const String &inner) {
+  return String(
+    "<!DOCTYPE html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>"
+    "<title>TinyMaker</title>"
+    "<link rel='icon' href=\"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'>"
+    "<rect width='16' height='16' rx='3' fill='%23e8720c'/>"
+    "<text x='8' y='12.5' font-family='Arial' font-size='11' font-weight='bold' fill='white' text-anchor='middle'>T</text></svg>\">"
+    "<style>"
+    "*{box-sizing:border-box}"
+    "body{margin:0;min-height:100vh;background:#1c1c1e;font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#eee}"
+    ".wrap{max-width:560px;margin:0 auto;padding:28px 18px}"
+    ".head{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;margin-bottom:18px}"
+    "h1{margin:0;font-size:24px;color:#e8720c}h2{font-size:17px;margin:0 0 12px;color:#eee}.fw{font-size:13px;color:#aaa}"
+    ".card{background:#2a2a2e;border:1px solid #444;border-radius:10px;padding:18px;margin:12px 0}"
+    ".grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}"
+    ".label{font-size:12px;color:#aaa}.value{font-size:16px;margin-top:4px}"
+    ".files{display:grid;gap:8px}.file{display:flex;align-items:center;justify-content:space-between;gap:10px;"
+    "border-top:1px solid #3a3a3f;padding-top:10px}.file:first-child{border-top:0;padding-top:0}"
+    ".rowActions{display:flex;gap:8px;align-items:center}"
+    ".meta{font-size:12px;color:#aaa;margin-top:3px}"
+    "input[type=file],input[type=number]{width:100%;margin:6px 0 12px;padding:10px;border:1px solid #555;border-radius:8px;background:#1c1c1e;color:#eee}"
+    "label span{display:block;font-size:13px;color:#aaa}.configGrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px 12px}"
+    ".check{display:flex;align-items:center;gap:8px;margin:6px 0 12px}.check input{width:auto}.check span{display:inline;color:#eee}"
+    ".actions{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}"
+    ".toolbar{display:flex;gap:8px;margin:12px 0}.toolbar button,.toolbar .button{width:auto;flex:1;margin-top:0;background:#3c3c42}"
+    ".banner{background:#3a2818;border-color:#e8720c}.banner strong{display:block;color:#ffb15f;margin-bottom:4px}"
+    ".progress{height:10px;border:1px solid #555;border-radius:999px;overflow:hidden;background:#1c1c1e;margin-top:10px}"
+    ".progress span{display:block;height:100%;width:45%;background:#e8720c;animation:barMove 1.1s infinite linear}"
+    "@keyframes barMove{0%{transform:translateX(-110%)}100%{transform:translateX(230%)}}"
+    "button,.button{display:inline-block;width:100%;border:0;border-radius:8px;background:#e8720c;color:#fff;padding:12px 14px;"
+    "font-size:15px;font-weight:600;text-align:center;text-decoration:none;cursor:pointer}"
+    ".small,.delete{width:auto;padding:9px 11px;font-size:13px}.delete{background:#7b2f2f}.secondaryBtn{background:#3c3c42}"
+    "button:disabled{background:#555;color:#aaa;cursor:not-allowed}"
+    ".button.secondary{background:#3c3c42;margin-top:10px}"
+    ".warn{color:#ffb15f}"
+    ".hidden{display:none}"
+    ".hint{font-size:13px;color:#aaa;margin:10px 0 0;line-height:1.4}"
+    ".configGrid .hint{grid-column:1/-1}"
+    "@media(max-width:520px){.grid,.configGrid,.actions{grid-template-columns:1fr}.head{display:block}.fw{margin-top:4px}.file{align-items:flex-start;flex-direction:column}.rowActions{width:100%}}"
+    "</style></head><body><main class='wrap'>") + inner + "</main></body></html>";
+}
+
+void handleRootPage() {
+  String fw =
+#ifdef FIRMWARE_VERSION
+    FIRMWARE_VERSION;
+#else
+    "unknown";
+#endif
+  String inner = R"SPA(
+<div class='head'><div><h1>TinyMaker</h1><div class='fw'>Firmware <span id='fwVersion'>{{FW}}</span></div></div></div>
+
+<section id='dryRunBanner' class='card banner hidden'>
+  <strong>Dry run mode enabled.</strong>
+  <div>Prints will not print, only for testing purposes.</div>
+  <button id='disableDryRunButton' class='button secondary' type='button'>Press here to disable</button>
+</section>
+
+<div class='toolbar'>
+  <button id='homeViewButton' type='button'>Dashboard</button>
+  <button id='configViewButton' type='button'>Config</button>
+  <a class='button secondary' href='/update'>Update</a>
+</div>
+
+<div id='homeView'>
+  <section class='card'>
+    <div class='grid'>
+      <div><div class='label'>State</div><div id='stateValue' class='value'>Loading</div></div>
+      <div><div class='label'>WiFi</div><div id='wifiValue' class='value'>-</div></div>
+      <div><div class='label'>IP</div><div id='ipValue' class='value'>-</div></div>
+      <div><div class='label'>Lifetime print time</div><div id='lifetimeValue' class='value'>-</div></div>
+      <div><div class='label'>SD card</div><div id='sdValue' class='value'>-</div></div>
+      <div id='printLayerBox' class='hidden'><div class='label'>Layer</div><div id='layerValue' class='value'>-</div></div>
+      <div id='printResinBox' class='hidden'><div class='label'>Resin</div><div id='resinValue' class='value'>-</div></div>
+      <div id='printRunBox' class='hidden'><div class='label'>Running time</div><div id='runValue' class='value'>-</div></div>
+      <div id='printRemainingBox' class='hidden'><div class='label'>Remaining time</div><div id='remainingValue' class='value'>-</div></div>
+    </div>
+    <div id='statusMsg' class='hint'></div>
+  </section>
+
+  <section id='printControls' class='card hidden'>
+    <h2>Print controls</h2>
+    <div class='actions'>
+      <button id='pauseButton' type='button'>Pause</button>
+      <button id='resumeButton' type='button'>Resume</button>
+      <button id='stopButton' class='delete' type='button'>Stop</button>
+    </div>
+  </section>
+
+  <section class='card'>
+    <h2>SD manager</h2>
+    <form id='uploadForm'>
+      <input id='uploadFile' type='file' name='file' accept='.sl1,.zip' required>
+      <button id='uploadButton' type='submit'>Upload model</button>
+    </form>
+    <div id='uploadHint' class='hint'>Uploaded SL1/ZIP files are unpacked into printable model folders on the SD card.</div>
+    <div id='filesList' class='files'></div>
+  </section>
+</div>
+
+<section id='modelPanel' class='card hidden'>
+  <button id='modelBackButton' class='button secondary' type='button'>Back to dashboard</button>
+  <h2 id='modelTitle'>Model</h2>
+  <div class='grid'>
+    <div><div class='label'>Layers</div><div id='modelLayers' class='value'>-</div></div>
+    <div><div class='label'>Height</div><div id='modelHeight' class='value'>-</div></div>
+    <div><div class='label'>Estimated time</div><div id='modelTime' class='value'>-</div></div>
+    <div id='modelResinBox' class='hidden'><div class='label'>Resin needed</div><div id='modelResin' class='value'>-</div></div>
+  </div>
+  <div id='modelProgress' class='progress hidden'><span></span></div>
+  <div class='actions'>
+    <button id='modelMlButton' type='button'>Calculate ml</button>
+    <button id='modelStartButton' type='button'>Start print</button>
+  </div>
+</section>
+
+<section id='configView' class='card hidden'>
+  <button id='configBackButton' class='button secondary' type='button'>Back to dashboard</button>
+  <h2>Config</h2>
+  <form id='configForm' class='configGrid'>
+    <label><span>Layer height (mm)</span><input name='layer_height' id='cfgLayerHeight' type='number' min='0.05' max='0.10' step='0.05'></label>
+    <label><span>Base exposure (s)</span><input name='base_exposure' id='cfgBaseExposure' type='number' min='10' max='60' step='1'></label>
+    <label><span>Regular exposure (s)</span><input name='regular_exposure' id='cfgRegularExposure' type='number' min='1' max='30' step='1'></label>
+    <label><span>Base layers</span><input name='base_layer' id='cfgBaseLayers' type='number' min='1' max='8' step='1'></label>
+    <label><span>Transition layers</span><input name='transition_layer' id='cfgTransitionLayers' type='number' min='0' max='10' step='1'></label>
+    <label><span>Slow lift distance (mm)</span><input name='slow_lift_distance' id='cfgSlowLiftDistance' type='number' min='1' max='3' step='1'></label>
+    <label><span>Fast lift distance (mm)</span><input name='fast_lift_distance' id='cfgFastLiftDistance' type='number' min='1' max='3' step='1'></label>
+    <label><span>Slow lift feedrate</span><input name='slow_lift_feedrate' id='cfgSlowLiftFeedrate' type='number' min='20' max='50' step='10'></label>
+    <label><span>Fast lift feedrate</span><input name='fast_lift_feedrate' id='cfgFastLiftFeedrate' type='number' min='20' max='50' step='10'></label>
+    <label><span>Drop back feedrate</span><input name='drop_back_feedrate' id='cfgDropBackFeedrate' type='number' min='20' max='50' step='10'></label>
+    <label><span>UI timeout (s, 0=off)</span><input name='ui_timeout' id='cfgUiTimeout' type='number' min='0' max='3600' step='5'></label>
+    <label class='check'><input name='dry_run' id='cfgDryRun' type='checkbox' value='1'><span>Dry run mode</span></label>
+    <button id='configSaveButton' type='submit'>Save config</button>
+  </form>
+  <button id='configDefaultsButton' class='button secondary' type='button'>Reset to defaults</button>
+  <div id='configHint' class='hint'>Config locks automatically while printing.</div>
+</section>
+
+<script>
+const $=id=>document.getElementById(id);
+let statusData=null,selectedModel='';
+const setText=(id,v)=>{const e=$(id);if(e)e.textContent=v;};
+const show=(id,on)=>{const e=$(id);if(e)e.classList.toggle('hidden',!on);};
+const enc=v=>encodeURIComponent(v||'').replace(/'/g,'%27');
+const esc=v=>String(v||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+const api=async(path,opt)=>{const r=await fetch(path,Object.assign({cache:'no-store'},opt||{}));let j={};try{j=await r.json();}catch(e){}if(!r.ok||j.ok===false)throw new Error(j.error||('HTTP '+r.status));return j;};
+const msg=(t,warn)=>{const e=$('statusMsg');e.textContent=t||'';e.classList.toggle('warn',!!warn);};
+const openView=view=>{
+  show('homeView',view==='home');
+  show('modelPanel',view==='model');
+  show('configView',view==='config');
+  if(view==='home')loadFiles();
+  if(view==='config')loadConfig();
+};
+
+const refreshStatus=async()=>{
+  try{
+    const s=await api('/api/status'); const was=statusData&&statusData.busy; statusData=s;
+    setText('stateValue',s.state); setText('wifiValue',s.wifiText); setText('ipValue',s.ip); setText('lifetimeValue',s.lifetimePrintTime); setText('sdValue',s.sdText);
+    setText('layerValue',s.layerText); setText('resinValue',s.resinText); setText('runValue',s.runTime); setText('remainingValue',s.remainingTime);
+    show('dryRunBanner',!!s.dryRun);
+    $('disableDryRunButton').disabled=!!s.busy;
+    $('disableDryRunButton').textContent=s.busy?'Disable when idle':'Press here to disable';
+    ['printLayerBox','printResinBox','printRunBox','printRemainingBox','printControls'].forEach(id=>show(id,s.busy));
+    const pause=$('pauseButton'), resume=$('resumeButton');
+    const showResume=s.canResume||s.resuming;
+    pause.classList.toggle('hidden',showResume);
+    resume.classList.toggle('hidden',!showResume);
+    pause.textContent=s.pausing?'Pausing...':'Pause';
+    resume.textContent=s.resuming?'Resuming...':'Resume';
+    pause.disabled=!s.canPause;
+    resume.disabled=!s.canResume;
+    $('stopButton').textContent=s.stopping?'Stopping...':'Stop';
+    $('stopButton').disabled=!s.canStop;
+    $('uploadButton').disabled=s.busy||!s.sdReady; $('uploadFile').disabled=s.busy||!s.sdReady;
+    if(s.busy){$('uploadHint').textContent='Uploads and SD actions are disabled while the printer is busy.';} else if(!s.sdReady){$('uploadHint').textContent='Insert an SD card before uploading or managing models.';} else {$('uploadHint').textContent='Uploaded SL1/ZIP files are unpacked into printable model folders on the SD card.';}
+    if(was!==s.busy){loadFiles();loadConfig();}
+  }catch(e){msg('Status unavailable: '+e.message,true);}
+};
+
+const loadFiles=async()=>{
+  const list=$('filesList');
+  if(statusData&&statusData.busy){list.innerHTML='<div class="hint warn">SD manager actions are disabled while printing.</div>';return;}
+  try{
+    const d=await api('/api/files');
+    if(!d.items.length){list.innerHTML='<div class="hint">No printable model folders or SL1/ZIP archives found.</div>';return;}
+    let h='';
+    d.items.forEach(it=>{
+      const meta=it.type==='model'?'Model folder':('Archive - '+Math.ceil((it.sizeBytes||0)/1024)+' KB');
+      h+='<div class="file"><div><strong>'+esc(it.name)+'</strong><div class="meta">'+esc(meta)+'</div></div><div class="rowActions">';
+      if(it.type==='model')h+='<button class="small secondaryBtn" onclick="modelDetails(\''+enc(it.name)+'\',false)">Details</button><button class="small" onclick="startPrint(\''+enc(it.name)+'\')">Start</button>';
+      h+='<button class="delete" onclick="deleteFile(\''+enc(it.name)+'\')">Delete</button></div></div>';
+    });
+    if(d.hiddenCount>0)h+='<div class="hint">'+d.hiddenCount+' other SD item(s) hidden.</div>';
+    list.innerHTML=h;
+  }catch(e){list.innerHTML='<div class="hint warn">'+e.message+'</div>';}
+};
+
+const modelDetails=async(nameEnc,estimate)=>{
+  const name=decodeURIComponent(nameEnc); selectedModel=name; openView('model');
+  if(!estimate){
+    setText('modelTitle',name); setText('modelLayers','Loading'); setText('modelHeight','-'); setText('modelTime','-');
+    show('modelResinBox',false); show('modelProgress',false);
+  } else {
+    $('modelMlButton').disabled=true;
+    $('modelMlButton').textContent='Calculating...';
+    show('modelProgress',true);
+  }
+  try{
+    const d=await api('/api/files/model?name='+enc(name)+(estimate?'&estimate=1':''));
+    setText('modelTitle',d.name); setText('modelLayers',d.layers); setText('modelHeight',Number(d.heightMm).toFixed(2)+' mm'); setText('modelTime',d.estimatedTime);
+    show('modelResinBox',!!d.resinEstimated); if(d.resinEstimated)setText('modelResin',Number(d.resinMl).toFixed(1)+' ml');
+  }catch(e){msg(e.message,true);}
+  finally{$('modelMlButton').disabled=false;$('modelMlButton').textContent='Calculate ml';show('modelProgress',false);}
+};
+
+const startPrint=async nameEnc=>{const name=decodeURIComponent(nameEnc||enc(selectedModel));if(!name||!confirm('Start this print?'))return;try{await api('/api/print/start?name='+enc(name),{method:'POST'});msg('Print queued.');openView('home');refreshStatus();}catch(e){msg(e.message,true);}};
+const deleteFile=async nameEnc=>{const name=decodeURIComponent(nameEnc);if(!confirm('Delete this SD item?'))return;try{await api('/api/files/delete?name='+enc(name),{method:'POST'});msg('Deleted '+name+'.');loadFiles();}catch(e){msg(e.message,true);}};
+const printCommand=async(cmd,confirmText)=>{if(confirmText&&!confirm(confirmText))return;try{await api('/api/print/'+cmd,{method:'POST'});refreshStatus();}catch(e){msg(e.message,true);}};
+
+const setConfigDisabled=disabled=>{document.querySelectorAll('#configForm input,#configForm button,#configDefaultsButton').forEach(e=>e.disabled=disabled);};
+const loadConfig=async()=>{
+  try{
+    const c=await api('/api/config');
+    $('cfgLayerHeight').value=Number(c.layerHeight).toFixed(2); $('cfgBaseExposure').value=c.baseExposure; $('cfgRegularExposure').value=c.regularExposure; $('cfgBaseLayers').value=c.baseLayers; $('cfgTransitionLayers').value=c.transitionLayers;
+    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun;
+    setConfigDisabled(!!c.locked); $('configHint').textContent=c.locked?'Config is locked while printing.':'Config locks automatically while printing.';
+  }catch(e){$('configHint').textContent=e.message;}
+};
+
+window.modelDetails=modelDetails;
+window.startPrint=startPrint;
+window.deleteFile=deleteFile;
+
+$('uploadForm').addEventListener('submit',async e=>{e.preventDefault();const f=$('uploadFile').files[0];if(!f)return;const fd=new FormData();fd.append('file',f);$('uploadButton').disabled=true;$('uploadHint').textContent='Uploading...';try{await api('/upload',{method:'POST',body:fd});$('uploadFile').value='';$('uploadHint').textContent='Upload complete.';loadFiles();}catch(err){$('uploadHint').textContent=err.message;}finally{$('uploadButton').disabled=false;}});
+$('configForm').addEventListener('submit',async e=>{e.preventDefault();try{await api('/api/config',{method:'POST',body:new FormData(e.target)});msg('Config saved.');loadConfig();}catch(err){msg(err.message,true);}});
+$('configDefaultsButton').addEventListener('click',async()=>{if(!confirm('Reset config to defaults?'))return;try{await api('/api/config/defaults',{method:'POST'});msg('Defaults restored.');loadConfig();}catch(e){msg(e.message,true);}});
+$('disableDryRunButton').addEventListener('click',async()=>{if(!confirm('Disable dry run mode? Future prints will use the UV LEDs.'))return;try{await api('/api/config/dry-run?enabled=0',{method:'POST'});msg('Dry run disabled.');loadConfig();refreshStatus();}catch(e){msg(e.message,true);}});
+$('homeViewButton').addEventListener('click',()=>openView('home'));
+$('configViewButton').addEventListener('click',()=>openView('config'));
+$('modelBackButton').addEventListener('click',()=>openView('home'));
+$('configBackButton').addEventListener('click',()=>openView('home'));
+$('pauseButton').addEventListener('click',()=>printCommand('pause','Pause this print?'));
+$('resumeButton').addEventListener('click',()=>printCommand('resume','Resume this print?'));
+$('stopButton').addEventListener('click',()=>printCommand('stop','Stop this print?'));
+$('modelMlButton').addEventListener('click',()=>modelDetails(enc(selectedModel),true));
+$('modelStartButton').addEventListener('click',()=>startPrint(enc(selectedModel)));
+
+openView('home');refreshStatus();loadConfig();setInterval(refreshStatus,2000);
+</script>
+)SPA";
+  inner.replace("{{FW}}", fw);
+  server.send(200, "text/html", rootStyledPage(inner));
 }
 
 // ===================================================================================
@@ -452,11 +1443,26 @@ void network_setup() {
     server.send(200, "application/json",
       "{\"api\":\"0.1\",\"server\":\"1.5.0\",\"text\":\"Prusa SLA (TinyMaker)\"}");
   });
+  server.on("/api/status", HTTP_GET, handleApiStatus);
+  server.on("/api/files", HTTP_GET, handleApiFiles);
+  server.on("/api/files/model", HTTP_GET, handleApiFileModel);
+  server.on("/api/files/delete", HTTP_POST, handleApiFileDelete);
+  server.on("/api/config", HTTP_GET, handleApiConfigGet);
+  server.on("/api/config", HTTP_POST, handleApiConfigSave);
+  server.on("/api/config/defaults", HTTP_POST, handleApiConfigDefaults);
+  server.on("/api/config/dry-run", HTTP_POST, handleApiConfigDryRun);
+  server.on("/api/print/start", HTTP_POST, handleApiPrintStart);
+  server.on("/api/print/pause", HTTP_POST, handleApiPrintPause);
+  server.on("/api/print/resume", HTTP_POST, handleApiPrintResume);
+  server.on("/api/print/stop", HTTP_POST, handleApiPrintStop);
   server.on("/api/files/local", HTTP_POST, finishUpload, handleUploadData);
 
   // Plain endpoint for curl / UVtools testing:
   //   curl -F "file=@model.zip" http://tinymaker.local/upload
   server.on("/upload", HTTP_POST, finishUpload, handleUploadData);
+
+  // Browser dashboard: http://tinymaker.local/
+  server.on("/", HTTP_GET, handleRootPage);
 
   // Web firmware update (users): http://tinymaker.local/update
   server.on("/update", HTTP_GET, handleUpdatePage);

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -856,8 +856,6 @@ String configJson() {
   out += uvLedEnabled ? "false" : "true";
   out += ",\"uvLedEnabled\":";
   out += uvLedEnabled ? "true" : "false";
-  out += ",\"experimentalSlicing\":";
-  out += experimentalSlicingEnabled ? "true" : "false";
   out += ",\"mqttEnabled\":";
   out += mqttEnabled ? "true" : "false";
   out += ",\"mqttConfigured\":";
@@ -890,7 +888,6 @@ void applyConfigRequest() {
   Drop_Back_Feedrate = formLong("drop_back_feedrate", Drop_Back_Feedrate, 20, 50);
   uiTimeoutSecs = formLong("ui_timeout", uiTimeoutSecs, 0, 3600);
   uvLedEnabled = !server.hasArg("dry_run");
-  experimentalSlicingEnabled = server.hasArg("experimental_slicing");
   mqttEnabled = server.hasArg("mqtt_enabled");
   mqttHost = formString("mqtt_host", mqttHost, 80);
   mqttPort = formLong("mqtt_port", mqttPort, 1, 65535);
@@ -925,7 +922,6 @@ void resetWebConfigToDefaults() {
   resetSettingsToDefault();
   uiTimeoutSecs = 0;
   uvLedEnabled = true;
-  experimentalSlicingEnabled = false;
   saveDeviceConfig();
 }
 
@@ -1370,10 +1366,6 @@ void sendRootStyledPage(PGM_P bodyBeforeFw, const char *fw, PGM_P bodyAfterFw) {
     ".actions{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}"
     ".toolbar{display:flex;gap:8px;margin:12px 0}.toolbar button,.toolbar .button{width:auto;flex:1;margin-top:0;background:#3c3c42}"
     ".banner{background:#3a2818;border-color:#e8720c}.banner strong{display:block;color:#ffb15f;margin-bottom:4px}"
-    ".fitOk{color:#5fd08a}.fitBad{color:#ff6b5f}"
-    ".profileBox{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px;margin-top:10px}"
-    ".previewGrid{display:grid;grid-template-columns:1fr;gap:10px;margin-top:12px}"
-    ".previewCanvas{width:100%;aspect-ratio:4/3;background:#111;border:1px solid #555;border-radius:8px;image-rendering:pixelated}"
     ".progress{height:10px;border:1px solid #555;border-radius:999px;overflow:hidden;background:#1c1c1e;margin-top:10px}"
     ".progress span{display:block;height:100%;width:45%;background:#e8720c;animation:barMove 1.1s infinite linear}"
     ".storageBar{height:10px;border:1px solid #555;border-radius:999px;overflow:hidden;background:#1c1c1e;margin-top:8px}"
@@ -1388,7 +1380,7 @@ void sendRootStyledPage(PGM_P bodyBeforeFw, const char *fw, PGM_P bodyAfterFw) {
     ".hidden{display:none}"
     ".hint{font-size:13px;color:#aaa;margin:10px 0 0;line-height:1.4}"
     ".configGrid .hint{grid-column:1/-1}"
-    "@media(max-width:520px){.grid,.configGrid,.actions,.profileBox{grid-template-columns:1fr}.head{display:block}.fw{margin-top:4px}.file{align-items:flex-start;flex-direction:column}.rowActions{width:100%}}"
+    "@media(max-width:520px){.grid,.configGrid,.actions{grid-template-columns:1fr}.head{display:block}.fw{margin-top:4px}.file{align-items:flex-start;flex-direction:column}.rowActions{width:100%}}"
     "</style></head><body><main class='wrap'>"));
   server.sendContent_P(bodyBeforeFw);
   server.sendContent(fw);
@@ -1415,7 +1407,6 @@ void handleRootPage() {
 
 <div class='toolbar'>
   <button id='homeViewButton' type='button'>Dashboard</button>
-  <button id='slicerViewButton' class='hidden' type='button'>Slicer</button>
   <button id='configViewButton' type='button'>Config</button>
   <a class='button secondary' href='/update'>Update</a>
 </div>
@@ -1477,44 +1468,6 @@ void handleRootPage() {
   </div>
 </section>
 
-<section id='slicerView' class='card hidden'>
-  <button id='slicerBackButton' class='button secondary' type='button'>Back to dashboard</button>
-  <h2>Prepare model</h2>
-  <div class='hint warn'>Beta slicer. Proceed with caution: STL files must already be the right way up; this does not add supports, hollow models, repair geometry, or optimize orientation.</div>
-  <input id='slicerFile' type='file' accept='.stl' />
-  <div class='profileBox'>
-    <div><div class='label'>Build area</div><div class='value'>40.8 x 30.6 mm</div></div>
-    <div><div class='label'>Max height</div><div class='value'>60 mm</div></div>
-    <div><div class='label'>LCD</div><div class='value'>320 x 240 px</div></div>
-  </div>
-  <div class='previewGrid'>
-    <div>
-      <div class='label'>Model preview</div>
-      <canvas id='modelPreviewCanvas' class='previewCanvas' width='320' height='240'></canvas>
-    </div>
-    <div id='layerPreviewBox' class='hidden'>
-      <div class='label'>Layer preview <span id='layerPreviewLabel'></span></div>
-      <canvas id='layerPreviewCanvas' class='previewCanvas' width='320' height='240'></canvas>
-      <input id='layerPreviewRange' type='range' min='1' max='1' value='1'>
-    </div>
-  </div>
-  <div class='grid' style='margin-top:12px'>
-    <div><div class='label'>Model size</div><div id='slicerSize' class='value'>-</div></div>
-    <div><div class='label'>Scaled size</div><div id='slicerScaledSize' class='value'>-</div></div>
-    <div><div class='label'>Scale</div><div id='slicerScaleValue' class='value'>100%</div></div>
-    <div><div class='label'>Fit check</div><div id='slicerFit' class='value'>Load STL</div></div>
-  </div>
-  <label><span>Scale (%)</span><input id='slicerScale' type='number' min='1' max='1000' step='1' value='100'></label>
-  <div id='slicerProgress' class='progress hidden'><span></span></div>
-  <div class='actions'>
-    <button id='slicerFitButton' type='button' disabled>Scale to fit</button>
-    <button id='slicerSliceButton' type='button' disabled>Slice to ZIP</button>
-    <button id='slicerDownloadButton' class='secondaryBtn' type='button' disabled>Download ZIP</button>
-    <button id='slicerUploadButton' type='button' disabled>Upload sliced ZIP</button>
-  </div>
-  <div id='slicerHint' class='hint'>STL fit checking is active. Layer slicing and ZIP generation are the next step.</div>
-</section>
-
 <section id='configView' class='card hidden'>
   <button id='configBackButton' class='button secondary' type='button'>Back to dashboard</button>
   <h2>Config</h2>
@@ -1531,7 +1484,6 @@ void handleRootPage() {
     <label><span>Drop back feedrate</span><input name='drop_back_feedrate' id='cfgDropBackFeedrate' type='number' min='20' max='50' step='10'></label>
     <label><span>UI timeout (s, 0=off)</span><input name='ui_timeout' id='cfgUiTimeout' type='number' min='0' max='3600' step='5'></label>
     <label class='check'><input name='dry_run' id='cfgDryRun' type='checkbox' value='1'><span>Dry run mode</span></label>
-    <label class='check'><input name='experimental_slicing' id='cfgExperimentalSlicing' type='checkbox' value='1'><span>Enable experimental slicing</span></label>
     <label class='check spanAll'><input name='mqtt_enabled' id='cfgMqttEnabled' type='checkbox' value='1'><span>Enable MQTT? (SmartHome integration)</span></label>
     <div id='mqttFields' class='spanAll hidden'>
       <div class='configGrid'>
@@ -1552,7 +1504,7 @@ void handleRootPage() {
 
 <script>
 const $=id=>document.getElementById(id);
-let statusData=null,selectedModel='',sdFreeBytes=0,sdTotalBytes=0,slicingEnabled=false;
+let statusData=null,selectedModel='',sdFreeBytes=0,sdTotalBytes=0;
 const setText=(id,v)=>{const e=$(id);if(e)e.textContent=v;};
 const show=(id,on)=>{const e=$(id);if(e)e.classList.toggle('hidden',!on);};
 const enc=v=>encodeURIComponent(v||'').replace(/'/g,'%27');
@@ -1620,14 +1572,10 @@ const uploadWithProgress=(fd,hintEl)=>{
     xhr.send(fd);
   });
 };
-const BUILD={x:40.8,y:30.6,z:60,px:320,py:240};
-let slicerModel=null,slicedZip=null;
 let statusInFlight=false,statusFailCount=0,pendingPrintCmd='',pendingPrintInFlight=false,localPrintStartedAt=0;
 const openView=view=>{
-  if(view==='slicer'&&!slicingEnabled){msg('Experimental slicing is disabled in Config.',true);view='config';}
   show('homeView',view==='home');
   show('modelPanel',view==='model');
-  show('slicerView',view==='slicer');
   show('configView',view==='config');
   if(view==='home')loadFiles();
   if(view==='config')loadConfig();
@@ -1751,205 +1699,6 @@ const tickLocalStatus=()=>{
   }
 };
 
-const fmtMm=v=>Number(v).toFixed(2)+' mm';
-const slicerSetFit=(ok,text)=>{const e=$('slicerFit');e.textContent=text;e.classList.toggle('fitOk',ok);e.classList.toggle('fitBad',!ok);};
-const clearLayerPreview=()=>{show('layerPreviewBox',false);const c=$('layerPreviewCanvas'),ctx=c.getContext('2d');ctx.fillStyle='#111';ctx.fillRect(0,0,c.width,c.height);};
-const drawModelPreview=()=>{
-  const c=$('modelPreviewCanvas'),ctx=c.getContext('2d');ctx.fillStyle='#111';ctx.fillRect(0,0,c.width,c.height);
-  ctx.strokeStyle='#444';ctx.lineWidth=1;ctx.strokeRect(0.5,0.5,c.width-1,c.height-1);
-  if(!slicerModel){ctx.fillStyle='#777';ctx.font='14px sans-serif';ctx.textAlign='center';ctx.fillText('Load STL',c.width/2,c.height/2);return;}
-  const scale=Math.max(1,Number($('slicerScale').value)||100)/100, tris=slicerModel.bounds.tris, step=Math.max(1,Math.ceil(tris.length/2500));
-  const map=p=>{const t=transformPt(p,scale);return {x:t.x/BUILD.x*c.width,y:c.height-(t.y/BUILD.y*c.height)};};
-  ctx.strokeStyle='#e8720c';ctx.globalAlpha=.28;ctx.lineWidth=.8;
-  for(let i=0;i<tris.length;i+=step){
-    const a=map(tris[i][0]),b=map(tris[i][1]),d=map(tris[i][2]);
-    ctx.beginPath();ctx.moveTo(a.x,a.y);ctx.lineTo(b.x,b.y);ctx.lineTo(d.x,d.y);ctx.closePath();ctx.stroke();
-  }
-  ctx.globalAlpha=1;ctx.strokeStyle='#5fd08a';ctx.strokeRect(0.5,0.5,c.width-1,c.height-1);
-};
-const stlFromBinary=buf=>{
-  const dv=new DataView(buf); const tris=dv.getUint32(80,true);
-  if(84+tris*50>buf.byteLength)throw new Error('Invalid binary STL');
-  const min=[Infinity,Infinity,Infinity],max=[-Infinity,-Infinity,-Infinity],out=[];
-  for(let i=0,p=84;i<tris;i++,p+=50){
-    const tri=[];
-    for(let v=0;v<3;v++){
-      const o=p+12+v*12;
-      const pt=[dv.getFloat32(o,true),dv.getFloat32(o+4,true),dv.getFloat32(o+8,true)];
-      tri.push(pt);
-      for(let a=0;a<3;a++){const n=pt[a]; if(n<min[a])min[a]=n; if(n>max[a])max[a]=n;}
-    }
-    out.push(tri);
-  }
-  return {min,max,tris:out};
-};
-const stlFromAscii=text=>{
-  const re=/vertex\s+([+-]?\d*\.?\d+(?:e[+-]?\d+)?)\s+([+-]?\d*\.?\d+(?:e[+-]?\d+)?)\s+([+-]?\d*\.?\d+(?:e[+-]?\d+)?)/ig;
-  const min=[Infinity,Infinity,Infinity],max=[-Infinity,-Infinity,-Infinity],verts=[],out=[]; let m,count=0;
-  while((m=re.exec(text))){
-    const pt=[parseFloat(m[1]),parseFloat(m[2]),parseFloat(m[3])]; verts.push(pt); count++;
-    for(let a=0;a<3;a++){const n=pt[a]; if(n<min[a])min[a]=n; if(n>max[a])max[a]=n;}
-    if(verts.length===3){out.push([verts[0],verts[1],verts[2]]);verts.length=0;}
-  }
-  if(!count)throw new Error('No STL vertices found');
-  return {min,max,tris:out};
-};
-const parseStl=buf=>{
-  try{return stlFromBinary(buf);}catch(e){}
-  return stlFromAscii(new TextDecoder().decode(buf));
-};
-const updateSlicerFit=()=>{
-  slicedZip=null;$('slicerUploadButton').disabled=true;$('slicerDownloadButton').disabled=true;show('slicerProgress',false);clearLayerPreview();drawModelPreview();
-  if(!slicerModel){setText('slicerScaleValue','100%');setText('slicerSize','-');setText('slicerScaledSize','-');slicerSetFit(false,'Load STL');$('slicerFitButton').disabled=true;$('slicerSliceButton').disabled=true;return;}
-  const scale=Math.max(1,Number($('slicerScale').value)||100)/100;
-  const d=slicerModel.dims, sx=d.x*scale, sy=d.y*scale, sz=d.z*scale;
-  const ok=sx<=BUILD.x&&sy<=BUILD.y&&sz<=BUILD.z;
-  setText('slicerScaleValue',Math.round(scale*100)+'%');
-  setText('slicerSize',fmtMm(d.x)+' x '+fmtMm(d.y)+' x '+fmtMm(d.z));
-  setText('slicerScaledSize',fmtMm(sx)+' x '+fmtMm(sy)+' x '+fmtMm(sz));
-  slicerSetFit(ok,ok?'Fits':'Too big');
-  $('slicerFitButton').disabled=ok;
-  $('slicerSliceButton').disabled=!ok;
-  $('slicerHint').textContent=ok?'Model fits TinyMaker. Ready to slice to ZIP.':'Model is larger than the TinyMaker build volume.';
-  drawModelPreview();
-};
-const loadSlicerFile=async file=>{
-  slicedZip=null;
-  if(!file){slicerModel=null;updateSlicerFit();return;}
-  $('slicerHint').textContent='Reading STL...';
-  try{
-    const b=parseStl(await file.arrayBuffer());
-    const dims={x:b.max[0]-b.min[0],y:b.max[1]-b.min[1],z:b.max[2]-b.min[2]};
-    slicerModel={name:file.name,bounds:b,dims};
-    $('slicerScale').value=100;
-    updateSlicerFit();
-  }catch(e){slicerModel=null;updateSlicerFit();$('slicerHint').textContent=e.message;}
-};
-const scaleSlicerToFit=()=>{
-  if(!slicerModel)return;
-  const d=slicerModel.dims;
-  const s=Math.min(BUILD.x/d.x,BUILD.y/d.y,BUILD.z/d.z,1);
-  const pct=Math.max(1,Math.floor(s*100));
-  if(pct<100&&!confirm('Model scaled to '+pct+'% to fit - continue?'))return;
-  $('slicerScale').value=pct;
-  updateSlicerFit();
-};
-const sleep=()=>new Promise(r=>setTimeout(r,0));
-const canvasBlob=(canvas,type)=>new Promise((res,rej)=>canvas.toBlob(b=>b?res(b):rej(new Error('PNG encode failed')),type));
-const safeZipName=name=>String(name||'model').replace(/\.[^.]+$/,'').replace(/[^A-Za-z0-9_-]+/g,'_')||'model';
-const transformPt=(p,scale)=>{
-  const b=slicerModel.bounds;
-  const cx=(b.min[0]+b.max[0])*0.5, cy=(b.min[1]+b.max[1])*0.5;
-  return {x:(p[0]-cx)*scale+BUILD.x*0.5,y:(p[1]-cy)*scale+BUILD.y*0.5,z:(p[2]-b.min[2])*scale};
-};
-const layerSegments=z=>{
-  const scale=Math.max(1,Number($('slicerScale').value)||100)/100, segs=[];
-  for(const tri of slicerModel.bounds.tris){
-    const pts=[transformPt(tri[0],scale),transformPt(tri[1],scale),transformPt(tri[2],scale)], hits=[];
-    for(let e=0;e<3;e++){
-      const a=pts[e],b=pts[(e+1)%3];
-      if((a.z<=z&&b.z>z)||(b.z<=z&&a.z>z)){
-        const t=(z-a.z)/(b.z-a.z);
-        hits.push({x:a.x+(b.x-a.x)*t,y:a.y+(b.y-a.y)*t});
-      }
-    }
-    if(hits.length===2)segs.push([hits[0],hits[1]]);
-  }
-  return segs;
-};
-const renderLayerPng=async z=>{
-  const canvas=document.createElement('canvas'); canvas.width=BUILD.px; canvas.height=BUILD.py;
-  const ctx=canvas.getContext('2d'), img=ctx.createImageData(BUILD.px,BUILD.py), data=img.data, segs=layerSegments(z);
-  for(let py=0;py<BUILD.py;py++){
-    const y=(py+0.5)/BUILD.py*BUILD.y, xs=[];
-    for(const s of segs){
-      const a=s[0],b=s[1];
-      if((a.y<=y&&b.y>y)||(b.y<=y&&a.y>y))xs.push(a.x+(y-a.y)*(b.x-a.x)/(b.y-a.y));
-    }
-    xs.sort((a,b)=>a-b);
-    for(let i=0;i+1<xs.length;i+=2){
-      const x1=Math.max(0,Math.min(BUILD.x,xs[i])), x2=Math.max(0,Math.min(BUILD.x,xs[i+1]));
-      let p1=Math.floor((BUILD.x-x2)/BUILD.x*BUILD.px), p2=Math.ceil((BUILD.x-x1)/BUILD.x*BUILD.px);
-      if(p1<0)p1=0;if(p2>BUILD.px)p2=BUILD.px;
-      for(let px=p1;px<p2;px++){const o=(py*BUILD.px+px)*4;data[o]=255;data[o+1]=255;data[o+2]=255;data[o+3]=255;}
-    }
-  }
-  ctx.putImageData(img,0,0);
-  return canvasBlob(canvas,'image/png');
-};
-const crcTable=(()=>{const t=[];for(let n=0;n<256;n++){let c=n;for(let k=0;k<8;k++)c=(c&1)?(0xedb88320^(c>>>1)):(c>>>1);t[n]=c>>>0;}return t;})();
-const crc32=buf=>{let c=0xffffffff;for(const b of buf)c=crcTable[(c^b)&255]^(c>>>8);return (c^0xffffffff)>>>0;};
-const u16=(a,v)=>{a.push(v&255,(v>>>8)&255);};
-const u32=(a,v)=>{a.push(v&255,(v>>>8)&255,(v>>>16)&255,(v>>>24)&255);};
-const makeZip=async files=>{
-  const encText=new TextEncoder(), chunks=[], central=[]; let offset=0;
-  for(const f of files){
-    const name=encText.encode(f.name), data=new Uint8Array(await f.blob.arrayBuffer()), crc=crc32(data), local=[];
-    u32(local,0x04034b50);u16(local,20);u16(local,0);u16(local,0);u16(local,0);u16(local,0);u32(local,crc);u32(local,data.length);u32(local,data.length);u16(local,name.length);u16(local,0);
-    chunks.push(new Uint8Array(local),name,data);
-    const cen=[];u32(cen,0x02014b50);u16(cen,20);u16(cen,20);u16(cen,0);u16(cen,0);u16(cen,0);u16(cen,0);u32(cen,crc);u32(cen,data.length);u32(cen,data.length);u16(cen,name.length);u16(cen,0);u16(cen,0);u16(cen,0);u16(cen,0);u32(cen,0);u32(cen,offset);
-    central.push(new Uint8Array(cen),name); offset+=local.length+name.length+data.length;
-  }
-  const centralSize=central.reduce((n,c)=>n+c.length,0), end=[];u32(end,0x06054b50);u16(end,0);u16(end,0);u16(end,files.length);u16(end,files.length);u32(end,centralSize);u32(end,offset);u16(end,0);
-  return new Blob([...chunks,...central,new Uint8Array(end)],{type:'application/zip'});
-};
-const showLayerPreview=idx=>{
-  if(!slicedZip||!slicedZip.layers||!slicedZip.layers.length)return;
-  const layer=Math.max(1,Math.min(slicedZip.layers.length,idx||1));
-  const c=$('layerPreviewCanvas'),ctx=c.getContext('2d'),img=new Image(),url=URL.createObjectURL(slicedZip.layers[layer-1]);
-  $('layerPreviewRange').value=layer;
-  $('layerPreviewLabel').textContent=layer+' / '+slicedZip.layers.length;
-  img.onload=()=>{ctx.fillStyle='#111';ctx.fillRect(0,0,c.width,c.height);ctx.drawImage(img,0,0,c.width,c.height);URL.revokeObjectURL(url);};
-  img.onerror=()=>URL.revokeObjectURL(url);
-  img.src=url;
-};
-const enableLayerPreview=layers=>{
-  $('layerPreviewRange').min=1;
-  $('layerPreviewRange').max=layers.length;
-  const mid=Math.max(1,Math.ceil(layers.length/2));
-  show('layerPreviewBox',true);
-  showLayerPreview(mid);
-};
-const sliceToZip=async()=>{
-  if(!slicerModel)return;
-  const scale=Math.max(1,Number($('slicerScale').value)||100)/100, height=slicerModel.dims.z*scale, lh=Number($('cfgLayerHeight').value)||0.05, layers=Math.max(1,Math.ceil(height/lh));
-  if(layers>1200&&!confirm('This will create '+layers+' layers. Continue?'))return;
-  $('slicerSliceButton').disabled=true;$('slicerUploadButton').disabled=true;$('slicerDownloadButton').disabled=true;show('slicerProgress',true);
-  const files=[];
-  try{
-    for(let i=1;i<=layers;i++){
-      $('slicerHint').textContent='Slicing layer '+i+' / '+layers+'...';
-      files.push({name:i+'.png',blob:await renderLayerPng((i-0.5)*lh)});
-      if(i%4===0)await sleep();
-    }
-    $('slicerHint').textContent='Packaging ZIP...';
-    const blob=await makeZip(files), name=safeZipName(slicerModel.name)+'.zip';
-    slicedZip={blob,name,layers:files.map(f=>f.blob)};
-    $('slicerUploadButton').disabled=false;
-    $('slicerDownloadButton').disabled=false;
-    enableLayerPreview(slicedZip.layers);
-    $('slicerHint').textContent='ZIP ready: '+name+' ('+Math.ceil(blob.size/1024)+' KB).';
-  }catch(e){$('slicerHint').textContent=e.message;}
-  finally{$('slicerSliceButton').disabled=false;show('slicerProgress',false);}
-};
-const downloadSlicedZip=()=>{
-  if(!slicedZip)return;
-  const a=document.createElement('a');
-  a.href=URL.createObjectURL(slicedZip.blob);
-  a.download=slicedZip.name;
-  a.click();
-  setTimeout(()=>URL.revokeObjectURL(a.href),10000);
-};
-const uploadSlicedZip=async()=>{
-  if(!slicedZip)return;
-  if(!checkUploadFits(slicedZip.blob.size,$('slicerHint')))return;
-  const fd=new FormData();fd.append('file',new File([slicedZip.blob],slicedZip.name,{type:'application/zip'}));
-  $('slicerUploadButton').disabled=true;$('slicerHint').textContent='Uploading sliced ZIP...';
-  const started=Date.now();
-  try{await uploadWithProgress(fd,$('slicerHint'));$('slicerHint').textContent='Upload complete in '+formatShortTime(Date.now()-started)+'.';openView('home');loadFiles();}
-  catch(e){$('slicerHint').textContent=e.message;$('slicerUploadButton').disabled=false;}
-};
-
 const setConfigDisabled=disabled=>{document.querySelectorAll('#configForm input,#configForm button,#configDefaultsButton,#configMqttResetButton').forEach(e=>e.disabled=disabled);};
 const configIsLocallyLocked=()=>!!(statusData&&statusData.busy);
 const updateMqttFields=()=>show('mqttFields',$('cfgMqttEnabled').checked);
@@ -1957,8 +1706,7 @@ const loadConfig=async()=>{
   try{
     const c=await api('/api/config');
     $('cfgLayerHeight').value=Number(c.layerHeight).toFixed(2); $('cfgBaseExposure').value=c.baseExposure; $('cfgRegularExposure').value=c.regularExposure; $('cfgBaseLayers').value=c.baseLayers; $('cfgTransitionLayers').value=c.transitionLayers;
-    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun; $('cfgExperimentalSlicing').checked=!!c.experimentalSlicing;
-    slicingEnabled=!!c.experimentalSlicing;show('slicerViewButton',slicingEnabled);if(!slicingEnabled&&!$('slicerView').classList.contains('hidden'))openView('home');
+    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun;
     $('cfgMqttEnabled').checked=!!c.mqttEnabled; $('cfgMqttHost').value=c.mqttHost||''; $('cfgMqttPort').value=c.mqttPort||1883; $('cfgMqttUser').value=c.mqttUser||''; $('cfgMqttPassword').value=''; $('cfgMqttTopic').value=c.mqttTopic||'TinyMaker';
     $('mqttHint').textContent=c.mqttPasswordSet?'Password is saved. Enter a new one only if you want to replace it.':'MQTT password is not set.';
     updateMqttFields();
@@ -1980,25 +1728,16 @@ $('configMqttResetButton').addEventListener('click',async()=>{if(!confirm('Reset
 $('disableDryRunButton').addEventListener('click',async()=>{if(!confirm('Disable dry run mode? Future prints will use the UV LEDs.'))return;try{await api('/api/config/dry-run?enabled=0',{method:'POST'});msg('Dry run disabled.');loadConfig();refreshStatus();}catch(e){msg(e.message,true);}});
 $('cfgMqttEnabled').addEventListener('change',updateMqttFields);
 $('homeViewButton').addEventListener('click',()=>openView('home'));
-$('slicerViewButton').addEventListener('click',()=>openView('slicer'));
 $('configViewButton').addEventListener('click',()=>openView('config'));
 $('modelBackButton').addEventListener('click',()=>openView('home'));
-$('slicerBackButton').addEventListener('click',()=>openView('home'));
 $('configBackButton').addEventListener('click',()=>openView('home'));
 $('pauseButton').addEventListener('click',()=>printCommand('pause','Pause this print?'));
 $('resumeButton').addEventListener('click',()=>printCommand('resume','Resume this print?'));
 $('stopButton').addEventListener('click',()=>printCommand('stop','Stop this print?'));
 $('modelMlButton').addEventListener('click',()=>modelDetails(enc(selectedModel),true));
 $('modelStartButton').addEventListener('click',()=>startPrint(enc(selectedModel)));
-$('slicerFile').addEventListener('change',e=>loadSlicerFile(e.target.files[0]));
-$('slicerScale').addEventListener('input',updateSlicerFit);
-$('slicerFitButton').addEventListener('click',scaleSlicerToFit);
-$('slicerSliceButton').addEventListener('click',sliceToZip);
-$('slicerDownloadButton').addEventListener('click',downloadSlicedZip);
-$('slicerUploadButton').addEventListener('click',uploadSlicedZip);
-$('layerPreviewRange').addEventListener('input',e=>showLayerPreview(Number(e.target.value)));
 
-drawModelPreview();clearLayerPreview();openView('home');refreshStatus();loadConfig();setInterval(tickLocalStatus,1000);setInterval(()=>{refreshStatus();retryPendingPrintCommand();},2000);
+openView('home');refreshStatus();loadConfig();setInterval(tickLocalStatus,1000);setInterval(()=>{refreshStatus();retryPendingPrintCommand();},2000);
 </script>
 )SPA";
   sendRootStyledPage(rootBodyBeforeFw, fw, rootBodyAfterFw);

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -84,6 +84,12 @@ uint32_t totalPrintSecs = 0;        // lifetime printing seconds (loaded in setu
 unsigned long printStartMs = 0;     // millis() when the current print started
 uint16_t uiTimeoutSecs = 0;         // 0 = never blank the UI screen
 bool uvLedEnabled = true;           // false = dry-run motion/display only
+bool mqttEnabled = false;           // Smart Home / MQTT integration scaffold
+String mqttHost = "";
+uint16_t mqttPort = 1883;
+String mqttUser = "";
+String mqttPass = "";
+String mqttTopic = "TinyMaker";
 unsigned long lastUiActivityMs = 0;
 bool uiBlanked = false;
 
@@ -99,6 +105,12 @@ void loadDeviceConfig() {
   totalPrintSecs = sysPrefs.getULong("printSecs", 0);
   uiTimeoutSecs = sysPrefs.getUShort("uiTimeout", 0);
   uvLedEnabled = sysPrefs.getBool("uvLed", true);
+  mqttEnabled = sysPrefs.getBool("mqttEnabled", false);
+  mqttHost = sysPrefs.getString("mqttHost", "");
+  mqttPort = sysPrefs.getUShort("mqttPort", 1883);
+  mqttUser = sysPrefs.getString("mqttUser", "");
+  mqttPass = sysPrefs.getString("mqttPass", "");
+  mqttTopic = sysPrefs.getString("mqttTopic", "TinyMaker");
   sysPrefs.end();
 }
 
@@ -106,6 +118,12 @@ void saveDeviceConfig() {
   sysPrefs.begin("tinymaker", false);
   sysPrefs.putUShort("uiTimeout", uiTimeoutSecs);
   sysPrefs.putBool("uvLed", uvLedEnabled);
+  sysPrefs.putBool("mqttEnabled", mqttEnabled);
+  sysPrefs.putString("mqttHost", mqttHost);
+  sysPrefs.putUShort("mqttPort", mqttPort);
+  sysPrefs.putString("mqttUser", mqttUser);
+  sysPrefs.putString("mqttPass", mqttPass);
+  sysPrefs.putString("mqttTopic", mqttTopic);
   sysPrefs.end();
 }
 

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -64,6 +64,8 @@ extern double resinUsedMl;
 extern double resinEstimateMl;
 bool estimateResin();               // returns true if user chose Start
 bool startFromResin = false;        // set when Start pressed on resin screen
+bool webStartPrint = false;         // set by the web SD manager after preview validation
+bool webResumePrint = false;        // set by the web dashboard while paused
 
 // Print-list selection kind: false = model folder (OK prints), true =
 // .sl1/.zip archive in the SD root (OK imports/converts it). Maintained by
@@ -80,11 +82,30 @@ void resetSettingsToDefault();
 Preferences sysPrefs;
 uint32_t totalPrintSecs = 0;        // lifetime printing seconds (loaded in setup)
 unsigned long printStartMs = 0;     // millis() when the current print started
+uint16_t uiTimeoutSecs = 0;         // 0 = never blank the UI screen
+bool uvLedEnabled = true;           // false = dry-run motion/display only
+unsigned long lastUiActivityMs = 0;
+bool uiBlanked = false;
 
 void savePrintTime() {
   totalPrintSecs += (millis() - printStartMs) / 1000UL;
   sysPrefs.begin("tinymaker", false);
   sysPrefs.putULong("printSecs", totalPrintSecs);
+  sysPrefs.end();
+}
+
+void loadDeviceConfig() {
+  sysPrefs.begin("tinymaker", true);
+  totalPrintSecs = sysPrefs.getULong("printSecs", 0);
+  uiTimeoutSecs = sysPrefs.getUShort("uiTimeout", 0);
+  uvLedEnabled = sysPrefs.getBool("uvLed", true);
+  sysPrefs.end();
+}
+
+void saveDeviceConfig() {
+  sysPrefs.begin("tinymaker", false);
+  sysPrefs.putUShort("uiTimeout", uiTimeoutSecs);
+  sysPrefs.putBool("uvLed", uvLedEnabled);
   sysPrefs.end();
 }
 
@@ -223,6 +244,49 @@ String FileName;          // Current file name
 File myfile;
 PNG png; // PNG decoder instance
 
+void savePrintSettings() {
+  EEPROM.write(1, Layer_Height * 100);
+  EEPROM.write(2, Base_Exposure);
+  EEPROM.write(3, Regular_Exposure);
+  EEPROM.write(4, Base_Layer);
+  EEPROM.write(5, Transition_Layer);
+  EEPROM.write(6, Slow_Lift_Distance);
+  EEPROM.write(7, Fast_Lift_Distance);
+  EEPROM.write(8, Slow_Lift_Feedrate);
+  EEPROM.write(9, Fast_Lift_Feedrate);
+  EEPROM.write(10, Drop_Back_Feedrate);
+  EEPROM.commit();
+}
+
+bool printerBusy() {
+  return screen == 1111 || screen == 1112 || screen == 11111 ||
+         screen == 11112 || screen == 11113;
+}
+
+bool handleUiTimeout() {
+  bool buttonPressed = digitalRead(buttonBack) == LOW ||
+                       digitalRead(buttonUp) == LOW ||
+                       digitalRead(buttonDown) == LOW ||
+                       digitalRead(buttonOK) == LOW;
+  if (buttonPressed) {
+    lastUiActivityMs = millis();
+    if (uiBlanked) {
+      uiBlanked = false;
+      screen1();
+      delay(200);
+      return true;                  // consume wake press
+    }
+  }
+
+  if (uiTimeoutSecs == 0 || uiBlanked || printerBusy()) return false;
+  if (!(screen == 1 || screen == 2 || screen == 3 || screen == 4)) return false;
+  if (millis() - lastUiActivityMs < (unsigned long)uiTimeoutSecs * 1000UL) return false;
+
+  gfx2->fillScreen(BLACK);          // visual blank; no LCD backlight pin is exposed
+  uiBlanked = true;
+  return false;
+}
+
 // ===================================================================================
 // Settings
 // ===================================================================================
@@ -343,16 +407,57 @@ void setup() {
     resetSettingsToDefault();
   }
 
-  // Lifetime print-hours counter (NVS, shown on the About screen)
-  sysPrefs.begin("tinymaker", true);
-  totalPrintSecs = sysPrefs.getULong("printSecs", 0);
-  sysPrefs.end();
+  // NVS-backed system values: lifetime print time + web/device settings.
+  loadDeviceConfig();
+  lastUiActivityMs = millis();
 
   delay(1000);
   #if ENABLE_NETWORK
   network_setup(); // SLIBBINAS WiFi + upload server (Network.ino)
   #endif
   screen1(); // jumps to Main Menu
+}
+
+bool prepareSelectedPrintPreview() {
+  uiFrame(ORANGE);
+  gfx2->setFont(&FreeSans8pt7b);
+  gfx2->setTextColor(WHITE);
+  gfx2->setTextSize(1);
+  gfx2->setCursor(22, 34);
+  gfx2->print("Processing files");
+  gfx2->setCursor(34, 52);
+  gfx2->print("Please wait...");
+  delay(500);
+
+  layer_counter = 0;
+  File entry;
+  do {
+    layer_counter += 100;
+    FileName = foldersel_long;
+    FileName += "/";
+    FileName += layer_counter;
+    FileName += ".png";
+    entry = SD.open(FileName);
+  } while(entry);
+  layer_counter -= 100;
+
+  do {
+    layer_counter++;
+    FileName = foldersel_long;
+    FileName += "/";
+    FileName += layer_counter;
+    FileName += ".png";
+    entry = SD.open(FileName);
+  } while(entry);
+  layer_counter--;
+
+  if (layer_counter <= 0 || layer_counter > MAX_LAYER_FILES) {
+    screen112();
+    return false;
+  }
+
+  screen111();
+  return true;
 }
 
 // ===================================================================================
@@ -366,6 +471,7 @@ void loop() {
   #if ENABLE_NETWORK
   network_loop(); // network uploads - only serviced while printer is idle
   #endif
+  if (handleUiTimeout()) return;
   // -----------------------------------------------------------------------------------
   // Back Button Handling
   // Only triggers if the button is pressed (LOW)
@@ -669,9 +775,9 @@ void loop() {
 
   // -----------------------------------------------------------------------------------
   // OK Button Handling
-  // (startFromResin lets the resin screen's "Start" flow straight into printing)
+  // (startFromResin/webStartPrint let non-OK flows start the existing print path)
   // -----------------------------------------------------------------------------------
-  if (digitalRead(buttonOK) == LOW || startFromResin) {
+  if (digitalRead(buttonOK) == LOW || startFromResin || webStartPrint) {
     switch (screen) {
       case 1:
       if (SD.begin(SDCS, SD_SCK_MHZ(16))){
@@ -709,51 +815,17 @@ void loop() {
         folderDown(root);
         break;
       }
-      uiFrame(ORANGE);
-      gfx2->setFont(&FreeSans8pt7b);
-      gfx2->setTextColor(WHITE);
-      gfx2->setTextSize(1);
-      gfx2->setCursor(22, 34);
-      gfx2->print("Processing files");
-      gfx2->setCursor(34, 52);
-      gfx2->print("Please wait...");
-      delay(500);
- 
-      layer_counter = 0;
-      File entry;
-      do {
-        layer_counter += 100;
-        FileName = foldersel_long;
-        FileName += "/";
-        FileName += layer_counter;
-        FileName += ".png";
-        entry = SD.open(FileName);        
-      } while(entry);
-      layer_counter -= 100;
-
-      do {
-        layer_counter++;
-        FileName = foldersel_long;
-        FileName += "/";
-        FileName += layer_counter;
-        FileName += ".png";
-        entry = SD.open(FileName);    
-      } while(entry);
-      layer_counter --; 
-
-      if (layer_counter <= MAX_LAYER_FILES){
-        screen111();
-      }else{
-        screen112();
-      }
+      prepareSelectedPrintPreview();
       }
         break;
       case 111: {
         startFromResin = false;   // consume the resin-screen Start request
+        webStartPrint = false;    // consume the web SD-manager Start request
         printStartMs = millis();  // print-hours accounting (incl. pauses)
         homing_canceled = false;
         print_paused = false;
         print_canceled = false;
+        webResumePrint = false;
         resinUsedMl = 0.0;        // reset cured-resin counter for this print
         current_state = 0;
         current_layer = 0;
@@ -774,7 +846,10 @@ void loop() {
         stepper.enableOutputs();
         long initial_homing = 0;
         long current_position;
-        while(!digitalRead(end_stop)){
+        while(!digitalRead(end_stop) && !homing_canceled && !print_canceled){
+          #if ENABLE_NETWORK
+          network_loop();
+          #endif
           stepper.moveTo(initial_homing);  // Set the position to move to
           initial_homing--;  // Decrease by 1 for next move if needed
           stepper.run();  // Start moving the stepper          
@@ -896,8 +971,12 @@ void loop() {
               stepper.move(20 * steps_mm);
             else
               stepper.moveTo(max_height * steps_mm);  
-            while (stepper.distanceToGo()!= 0)
+            while (stepper.distanceToGo()!= 0) {
+              #if ENABLE_NETWORK
+              network_loop();
+              #endif
               stepper.run();
+            }
             stepper.disableOutputs();
             delay(10); 
 
@@ -908,6 +987,9 @@ void loop() {
             screen1111DOWN();
               
             while(print_paused == true){
+              #if ENABLE_NETWORK
+              network_loop();
+              #endif
               Duration2 = millis()-startTime2;
               if (Duration2 >= 500 && digitalRead(buttonUp) == LOW && screen == 1112){
               screen1111UP();
@@ -953,7 +1035,8 @@ void loop() {
               print_canceled = true;
               print_paused = false;
               }  
-              if (Duration2 >= 500 && digitalRead(buttonOK) == LOW && screen == 11113){
+              if ((Duration2 >= 500 && digitalRead(buttonOK) == LOW && screen == 11113) || webResumePrint){
+              webResumePrint = false;
               screen1111();
               current_state = 7;
               screen1111_state();           
@@ -964,8 +1047,12 @@ void loop() {
               stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60);
               stepper.enableOutputs();
               stepper.moveTo(Position_before_pause);  
-              while (stepper.distanceToGo()!= 0)
+              while (stepper.distanceToGo()!= 0) {
+                #if ENABLE_NETWORK
+                network_loop();
+                #endif
                 stepper.run();
+              }
               stepper.disableOutputs();
               delay(10);
               gfx2->fillRect(136, 12, 16, 16, RED);
@@ -1095,17 +1182,7 @@ void loop() {
       }
         break; 
       case 3111:
-      EEPROM.write(1, Layer_Height*100);
-      EEPROM.write(2, Base_Exposure);
-      EEPROM.write(3, Regular_Exposure);
-      EEPROM.write(4, Base_Layer);
-      EEPROM.write(5, Transition_Layer);
-      EEPROM.write(6, Slow_Lift_Distance);
-      EEPROM.write(7, Fast_Lift_Distance);
-      EEPROM.write(8, Slow_Lift_Feedrate);
-      EEPROM.write(9, Fast_Lift_Feedrate);
-      EEPROM.write(10, Drop_Back_Feedrate);
-      EEPROM.commit(); 
+      savePrintSettings();
       if(setting_item_updown == 1){
         setting_item ++;
         screen31UP();

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -291,6 +291,7 @@ bool handleUiTimeout() {
     lastUiActivityMs = millis();
     if (uiBlanked) {
       uiBlanked = false;
+      ((Arduino_TFT *)gfx2)->displayOn();
       screen1();
       delay(200);
       return true;                  // consume wake press
@@ -301,7 +302,8 @@ bool handleUiTimeout() {
   if (!(screen == 1 || screen == 2 || screen == 3 || screen == 4)) return false;
   if (millis() - lastUiActivityMs < (unsigned long)uiTimeoutSecs * 1000UL) return false;
 
-  gfx2->fillScreen(BLACK);          // visual blank; no LCD backlight pin is exposed
+  gfx2->fillScreen(BLACK);
+  ((Arduino_TFT *)gfx2)->displayOff(); // may not cut backlight if it is hard-wired
   uiBlanked = true;
   return false;
 }

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -84,7 +84,6 @@ uint32_t totalPrintSecs = 0;        // lifetime printing seconds (loaded in setu
 unsigned long printStartMs = 0;     // millis() when the current print started
 uint16_t uiTimeoutSecs = 0;         // 0 = never blank the UI screen
 bool uvLedEnabled = true;           // false = dry-run motion/display only
-bool experimentalSlicingEnabled = false;
 bool mqttEnabled = false;           // Smart Home / MQTT integration scaffold
 String mqttHost = "";
 uint16_t mqttPort = 1883;
@@ -106,7 +105,6 @@ void loadDeviceConfig() {
   totalPrintSecs = sysPrefs.getULong("printSecs", 0);
   uiTimeoutSecs = sysPrefs.getUShort("uiTimeout", 0);
   uvLedEnabled = sysPrefs.getBool("uvLed", true);
-  experimentalSlicingEnabled = sysPrefs.getBool("expSlicing", false);
   mqttEnabled = sysPrefs.getBool("mqttEnabled", false);
   mqttHost = sysPrefs.getString("mqttHost", "");
   mqttPort = sysPrefs.getUShort("mqttPort", 1883);
@@ -120,7 +118,6 @@ void saveDeviceConfig() {
   sysPrefs.begin("tinymaker", false);
   sysPrefs.putUShort("uiTimeout", uiTimeoutSecs);
   sysPrefs.putBool("uvLed", uvLedEnabled);
-  sysPrefs.putBool("expSlicing", experimentalSlicingEnabled);
   sysPrefs.putBool("mqttEnabled", mqttEnabled);
   sysPrefs.putString("mqttHost", mqttHost);
   sysPrefs.putUShort("mqttPort", mqttPort);

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -84,6 +84,7 @@ uint32_t totalPrintSecs = 0;        // lifetime printing seconds (loaded in setu
 unsigned long printStartMs = 0;     // millis() when the current print started
 uint16_t uiTimeoutSecs = 0;         // 0 = never blank the UI screen
 bool uvLedEnabled = true;           // false = dry-run motion/display only
+bool experimentalSlicingEnabled = false;
 bool mqttEnabled = false;           // Smart Home / MQTT integration scaffold
 String mqttHost = "";
 uint16_t mqttPort = 1883;
@@ -105,6 +106,7 @@ void loadDeviceConfig() {
   totalPrintSecs = sysPrefs.getULong("printSecs", 0);
   uiTimeoutSecs = sysPrefs.getUShort("uiTimeout", 0);
   uvLedEnabled = sysPrefs.getBool("uvLed", true);
+  experimentalSlicingEnabled = sysPrefs.getBool("expSlicing", false);
   mqttEnabled = sysPrefs.getBool("mqttEnabled", false);
   mqttHost = sysPrefs.getString("mqttHost", "");
   mqttPort = sysPrefs.getUShort("mqttPort", 1883);
@@ -118,6 +120,7 @@ void saveDeviceConfig() {
   sysPrefs.begin("tinymaker", false);
   sysPrefs.putUShort("uiTimeout", uiTimeoutSecs);
   sysPrefs.putBool("uvLed", uvLedEnabled);
+  sysPrefs.putBool("expSlicing", experimentalSlicingEnabled);
   sysPrefs.putBool("mqttEnabled", mqttEnabled);
   sysPrefs.putString("mqttHost", mqttHost);
   sysPrefs.putUShort("mqttPort", mqttPort);
@@ -136,6 +139,7 @@ const char *otaLatestVerStr();
 int otaVersionState();
 bool otaHasUpdate();
 void otaInstallLatest();
+void network_service_window(uint16_t durationMs);
 void screen422();   // "install from file" screen (Interface.ino, #if-guarded)
 #endif
 
@@ -855,6 +859,9 @@ void loop() {
         screen1111_state();
         screen1111UP();
         delay(500);
+        #if ENABLE_NETWORK
+        network_service_window(500);
+        #endif
 
         // -------------------------------------------------------------------------------
         // Homing Sequence
@@ -865,9 +872,6 @@ void loop() {
         long initial_homing = 0;
         long current_position;
         while(!digitalRead(end_stop) && !homing_canceled && !print_canceled){
-          #if ENABLE_NETWORK
-          network_loop();
-          #endif
           stepper.moveTo(initial_homing);  // Set the position to move to
           initial_homing--;  // Decrease by 1 for next move if needed
           stepper.run();  // Start moving the stepper          
@@ -939,6 +943,9 @@ void loop() {
           estimated_minutes = (estimated_seconds % 3600) / 60;
                         
           print_next_png();
+          #if ENABLE_NETWORK
+          network_service_window(160);
+          #endif
             
           if (screen != 11111 && screen != 11112){                
             gfx2->fillRoundRect(2, 38, 116, 40, 3, BLACK);
@@ -967,6 +974,9 @@ void loop() {
                   
           turn_on_LED();          
           gfx1->fillScreen(BLACK);
+          #if ENABLE_NETWORK
+          network_service_window(160);
+          #endif
           
           if (current_state != 4 && current_state != 5){
             current_state = 2;
@@ -974,6 +984,9 @@ void loop() {
           }
           lift_print();
           delay(50);
+          #if ENABLE_NETWORK
+          network_service_window(160);
+          #endif
           
           if(current_layer == layer_counter)
             break;
@@ -990,9 +1003,6 @@ void loop() {
             else
               stepper.moveTo(max_height * steps_mm);  
             while (stepper.distanceToGo()!= 0) {
-              #if ENABLE_NETWORK
-              network_loop();
-              #endif
               stepper.run();
             }
             stepper.disableOutputs();
@@ -1066,9 +1076,6 @@ void loop() {
               stepper.enableOutputs();
               stepper.moveTo(Position_before_pause);  
               while (stepper.distanceToGo()!= 0) {
-                #if ENABLE_NETWORK
-                network_loop();
-                #endif
                 stepper.run();
               }
               stepper.disableOutputs();
@@ -1085,7 +1092,10 @@ void loop() {
           if (!print_canceled){
             current_state = 3;
             screen1111_state();
-            lower_print();              
+            lower_print();
+            #if ENABLE_NETWORK
+            network_service_window(160);
+            #endif
           }           
         } 
         if (!homing_canceled){

--- a/src/UVLED.ino
+++ b/src/UVLED.ino
@@ -20,9 +20,12 @@ void turn_on_LED(){
   startTime = millis();
   Duration = 0;
   startTime2 = millis();
-  digitalWrite(LED, HIGH); 
+  digitalWrite(LED, uvLedEnabled ? HIGH : LOW);
   
-  while (Duration <= ExposureMillis){
+  while (Duration <= ExposureMillis && !print_canceled){
+    #if ENABLE_NETWORK
+    network_loop();
+    #endif
     Duration = millis()-startTime;
     Duration2 = millis()-startTime2;
     

--- a/src/UVLED.ino
+++ b/src/UVLED.ino
@@ -23,9 +23,6 @@ void turn_on_LED(){
   digitalWrite(LED, uvLedEnabled ? HIGH : LOW);
   
   while (Duration <= ExposureMillis && !print_canceled){
-    #if ENABLE_NETWORK
-    network_loop();
-    #endif
     Duration = millis()-startTime;
     Duration2 = millis()-startTime2;
     


### PR DESCRIPTION
## Summary
Adds a browser-based TinyMakerWifi dashboard at `/` with SD card management, print monitoring/control, device config, dry-run support, and MQTT/Home Assistant integration.

## Changes
- Added single-page web dashboard backed by JSON API endpoints.
- Added SD manager for upload, delete, model details, resin estimate, and start print.
- Added print controls: pause, resume, stop, with confirmation and busy-state handling.
- Added live print status: state, layers, resin, running time, remaining time, SD, WiFi, and lifetime print time.
- Added web config view with reset defaults, UI timeout, dry-run mode, and config locking while printing.
- Added dry-run banner and `Testing` states when UV output is disabled.
- Kept dashboard/API reachable during prints by servicing networking in long print loops.
- Added MQTT config UI and persisted broker settings.
- Added separate `Reset MQTT`; normal defaults preserve MQTT settings when configured.
- Added MQTT publishing with Home Assistant discovery via `PubSubClient`.
- Publishes retained availability and status topics for HA sensors.

## Safety
- Firmware update remains gated to the printer Update screen.
- SD actions, uploads, config edits, and print starts are blocked while busy.
- Dry-run mode prevents UV output while allowing motion/display testing.

