### PR TITLE
Auto update checker and bug fix for screen timeout

### DIFF
--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -333,7 +333,7 @@ bool advancedMqttConfigured() {
 }
 
 int advancedOptionCount() {
-  int count = 3; // screen timeout, dry run, WiFi
+  int count = 4; // screen timeout, dry run, boot update, WiFi
   if (wifiEnabled) count++; // web dashboard
   if (wifiEnabled && advancedMqttConfigured()) count++; // MQTT
   return count;
@@ -342,9 +342,10 @@ int advancedOptionCount() {
 String advancedLabel(int item) {
   if (item == 1) return "Screen timeout";
   if (item == 2) return "Dry run";
-  if (item == 3) return "WiFi";
-  if (wifiEnabled && item == 4) return "Web access";
-  if (wifiEnabled && advancedMqttConfigured() && item == 5) return "MQTT";
+  if (item == 3) return "Boot update";
+  if (item == 4) return "WiFi";
+  if (wifiEnabled && item == 5) return "Web access";
+  if (wifiEnabled && advancedMqttConfigured() && item == 6) return "MQTT";
   return "";
 }
 
@@ -354,9 +355,10 @@ String advancedValue(int item) {
     return String(uiTimeoutSecs) + "s";
   }
   if (item == 2) return uvLedEnabled ? "Off" : "On";
-  if (item == 3) return wifiEnabled ? "On" : "Off";
-  if (wifiEnabled && item == 4) return webDashboardEnabled ? "On" : "Off";
-  if (wifiEnabled && advancedMqttConfigured() && item == 5) return mqttEnabled ? "On" : "Off";
+  if (item == 3) return bootUpdateCheckEnabled ? "On" : "Off";
+  if (item == 4) return wifiEnabled ? "On" : "Off";
+  if (wifiEnabled && item == 5) return webDashboardEnabled ? "On" : "Off";
+  if (wifiEnabled && advancedMqttConfigured() && item == 6) return mqttEnabled ? "On" : "Off";
   return "";
 }
 
@@ -406,6 +408,8 @@ void advancedOptionsSelect() {
   } else if (advanced_item == 2) {
     uvLedEnabled = !uvLedEnabled;
   } else if (advanced_item == 3) {
+    bootUpdateCheckEnabled = !bootUpdateCheckEnabled;
+  } else if (advanced_item == 4) {
     wifiEnabled = !wifiEnabled;
     if (!wifiEnabled) {
       webDashboardEnabled = false;
@@ -413,13 +417,13 @@ void advancedOptionsSelect() {
     } else {
       webDashboardEnabled = true;
     }
-  } else if (wifiEnabled && advanced_item == 4) {
+  } else if (wifiEnabled && advanced_item == 5) {
     webDashboardEnabled = !webDashboardEnabled;
-  } else if (wifiEnabled && advancedMqttConfigured() && advanced_item == 5) {
+  } else if (wifiEnabled && advancedMqttConfigured() && advanced_item == 6) {
     mqttEnabled = !mqttEnabled;
   }
   saveDeviceConfig();
-  if (advanced_item == 3) {
+  if (advanced_item == 4) {
     // WiFi state only changes at boot (network_setup has no runtime
     // teardown/bring-up path), so offer a reboot to apply it now.
     screenRebootConfirm();
@@ -497,6 +501,40 @@ void screenUpdateWifiConfirm(){
   gfx2->print("Enable for update?");
   uiButtons("No", "Yes", 0x879F);
   screen = 423;
+}
+
+void screenBootUpdateAvailable(){
+  gfx2->fillScreen(BLACK);
+  uiTitle("Firmware update");
+  gfx2->setFont(NULL);
+  gfx2->setTextColor(WHITE);
+  gfx2->setCursor(5, 26);
+  gfx2->print("Installed: v");
+#ifdef FIRMWARE_VERSION
+  gfx2->print(FIRMWARE_VERSION);
+#else
+  gfx2->print("?");
+#endif
+  gfx2->setCursor(5, 40);
+  gfx2->setTextColor(0x879F);
+  gfx2->print("Available: v");
+  gfx2->print(otaLatestVerStr());
+  gfx2->setFont(&FreeSans8pt7b);
+  uiButtons("Cancel", "Install", 0x879F);
+  screen = 424;
+}
+
+void screenBootUpdateDisableConfirm(){
+  uiFrame(ORANGE);
+  gfx2->setFont(&FreeSans8pt7b);
+  gfx2->setTextColor(WHITE);
+  gfx2->setTextSize(1);
+  gfx2->setCursor(8, 21);
+  gfx2->print("Disable boot");
+  gfx2->setCursor(8, 43);
+  gfx2->print("update check?");
+  uiButtons("No", "Yes", 0x879F);
+  screen = 425;
 }
 #endif
 

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -829,6 +829,7 @@ bool queueModelPrint(const String &requestedName, String &error) {
   selIsArchive = false;
   root = SD.open("/");
 
+  wakeUiForRemoteAction();
   if (!prepareSelectedPrintPreview()) {
     delay(1000);
     screen1();
@@ -877,6 +878,8 @@ String configJson() {
   out += wifiEnabled ? "true" : "false";
   out += ",\"webDashboardEnabled\":";
   out += webDashboardEnabled ? "true" : "false";
+  out += ",\"bootUpdateCheck\":";
+  out += bootUpdateCheckEnabled ? "true" : "false";
   out += ",\"mqttEnabled\":";
   out += mqttEnabled ? "true" : "false";
   out += ",\"mqttConfigured\":";
@@ -912,6 +915,7 @@ void applyConfigRequest() {
   uvLedEnabled = !server.hasArg("dry_run");
   wifiEnabled = server.hasArg("wifi_enabled");
   webDashboardEnabled = wifiEnabled && server.hasArg("web_dashboard_enabled");
+  bootUpdateCheckEnabled = server.hasArg("boot_update_check");
   mqttEnabled = server.hasArg("mqtt_enabled");
   if (!wifiEnabled) mqttEnabled = false;
   mqttHost = formString("mqtt_host", mqttHost, 80);
@@ -957,6 +961,7 @@ void resetWebConfigToDefaults() {
   uvLedEnabled = true;
   wifiEnabled = true;
   webDashboardEnabled = true;
+  bootUpdateCheckEnabled = true;
   saveDeviceConfig();
 }
 
@@ -1418,6 +1423,9 @@ void sendRootStyledPage(PGM_P bodyBeforeFw, const char *fw, PGM_P bodyAfterFw) {
     ".small,.delete{width:auto;padding:9px 11px;font-size:13px}.delete{background:#7b2f2f}.secondaryBtn{background:#3c3c42}"
     "button:disabled{background:#555;color:#aaa;cursor:not-allowed}"
     ".button.secondary{background:#3c3c42;margin-top:10px}"
+    "body.updating main>*:not(#updateBanner){opacity:.55;pointer-events:none}"
+    "body.updating #updateBanner{opacity:1;pointer-events:auto}"
+    "body.updating #updateNowButton{pointer-events:none}"
     ".warn{color:#ffb15f}"
     ".hidden{display:none}"
     ".hint{font-size:13px;color:#aaa;margin:10px 0 0;line-height:1.4}"
@@ -1445,6 +1453,12 @@ void handleRootPage() {
   <strong>Dry run mode enabled.</strong>
   <div>Prints will not print, only for testing purposes.</div>
   <button id='disableDryRunButton' class='button secondary' type='button'>Press here to disable</button>
+</section>
+
+<section id='updateBanner' class='card banner hidden'>
+  <strong>Firmware update available.</strong>
+  <div id='updateText'>A newer firmware is available.</div>
+  <button id='updateNowButton' class='button secondary' type='button'>Update now</button>
 </section>
 
 <div class='toolbar'>
@@ -1526,6 +1540,7 @@ void handleRootPage() {
     <label><span>VAT size (ml)</span><input name='vat_ml' id='cfgVatMl' type='number' min='10' max='40' step='1'></label>
     <label><span>UI timeout (s, 0=off)</span><input name='ui_timeout' id='cfgUiTimeout' type='number' min='0' max='3600' step='5'></label>
     <label class='check'><input name='dry_run' id='cfgDryRun' type='checkbox' value='1'><span>Dry run mode</span></label>
+    <label class='check'><input name='boot_update_check' id='cfgBootUpdateCheck' type='checkbox' value='1'><span>Boot update check</span></label>
     <label class='check'><input name='wifi_enabled' id='cfgWifiEnabled' type='checkbox' value='1'><span>WiFi</span></label>
     <label class='check'><input name='web_dashboard_enabled' id='cfgWebDashboardEnabled' type='checkbox' value='1'><span>Web access</span></label>
     <label class='check spanAll'><input name='mqtt_enabled' id='cfgMqttEnabled' type='checkbox' value='1'><span>Enable MQTT? (SmartHome integration)</span></label>
@@ -1549,8 +1564,12 @@ void handleRootPage() {
 <script>
 const $=id=>document.getElementById(id);
 let statusData=null,selectedModel='',sdFreeBytes=0,sdTotalBytes=0;
+let updateInfo=null,waitingForUpdateReboot=false;
+const OTA_VERSION_URL='https://slibbinas.github.io/TinyMakerWifi/version.txt';
+const currentFwVersion=()=>($('fwVersion').textContent||'').trim();
 const setText=(id,v)=>{const e=$(id);if(e)e.textContent=v;};
 const show=(id,on)=>{const e=$(id);if(e)e.classList.toggle('hidden',!on);};
+const setUpdateLock=on=>{waitingForUpdateReboot=!!on;document.body.classList.toggle('updating',!!on);};
 const enc=v=>encodeURIComponent(v||'').replace(/'/g,'%27');
 const esc=v=>String(v||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 const api=async(path,opt,timeoutMs)=>{
@@ -1564,6 +1583,61 @@ const api=async(path,opt,timeoutMs)=>{
   finally{if(timer)clearTimeout(timer);}
 };
 const msg=(t,warn)=>{const e=$('statusMsg');e.textContent=t||'';e.classList.toggle('warn',!!warn);};
+const versionParts=v=>String(v||'').trim().replace(/^v/i,'').split('.').map(n=>parseInt(n,10)||0);
+const compareVersions=(a,b)=>{const av=versionParts(a),bv=versionParts(b);for(let i=0;i<3;i++){if((av[i]||0)!==(bv[i]||0))return(av[i]||0)-(bv[i]||0);}return 0;};
+const checkFirmwareUpdate=async()=>{
+  if(waitingForUpdateReboot)return;
+  try{
+    const r=await fetch(OTA_VERSION_URL,{cache:'no-store'});
+    if(!r.ok)throw new Error('HTTP '+r.status);
+    const lines=(await r.text()).split(/\r?\n/).map(s=>s.trim()).filter(Boolean);
+    const latest=lines[0]||'',url=lines[1]||'';
+    if(latest&&url&&compareVersions(latest,currentFwVersion())>0){
+      updateInfo={version:latest,url:url};
+      setText('updateText','Version v'+latest+' is available. Current: v'+currentFwVersion()+'.');
+      show('updateBanner',true);
+    }else{
+      updateInfo=null;
+      show('updateBanner',false);
+    }
+  }catch(e){}
+};
+const waitForUpdateReturn=()=>{
+  let sawOffline=false,attempts=0;
+  const timer=setInterval(async()=>{
+    attempts++;
+    try{
+      await api('/api/status',null,5000);
+      if(sawOffline||attempts>30){clearInterval(timer);location.reload();}
+    }catch(e){sawOffline=true;}
+  },4000);
+};
+const startFirmwareUpdate=async()=>{
+  if(!updateInfo)return;
+  if(statusData&&statusData.busy){msg('Updates are disabled while printing.',true);return;}
+  if(!confirm('Are you sure you want to update?'))return;
+  const fd=new FormData();fd.append('version',updateInfo.version);fd.append('url',updateInfo.url);
+  $('updateNowButton').disabled=true;
+  try{
+    await api('/api/update/install',{method:'POST',body:fd},8000);
+  }catch(e){
+    $('updateNowButton').disabled=false;
+    $('updateNowButton').textContent='Update now';
+    if(e.message.indexOf('firmware is not newer')>=0){
+      setText('updateText','Firmware is already current. Reloading dashboard...');
+      updateInfo=null;
+      setTimeout(()=>location.reload(),1000);
+      return;
+    }
+    msg(e.message,true);
+    checkFirmwareUpdate();
+    return;
+  }
+  setUpdateLock(true);
+  $('updateNowButton').textContent='Update started';
+  setText('updateText','Update started. Waiting for the printer to come back online...');
+  waitForUpdateReturn();
+};
 const bytesNum=v=>Number(v||0)||0;
 const formatBytes=v=>{
   let n=bytesNum(v),u=['B','KB','MB','GB'],i=0;
@@ -1638,6 +1712,8 @@ const applyStatus=s=>{
     show('dryRunBanner',!!s.dryRun);
     $('disableDryRunButton').disabled=!!s.busy;
     $('disableDryRunButton').textContent=s.busy?'Disable when idle':'Press here to disable';
+    $('updateNowButton').disabled=!!s.busy||waitingForUpdateReboot;
+    if(!waitingForUpdateReboot)$('updateNowButton').textContent=s.busy?'Update when idle':'Update now';
     ['printLayerBox','printResinBox','printRunBox','printRemainingBox','printControls'].forEach(id=>show(id,s.busy));
     const pause=$('pauseButton'), resume=$('resumeButton');
     const showResume=s.canResume||s.resuming;
@@ -1762,7 +1838,7 @@ const loadConfig=async()=>{
   try{
     const c=await api('/api/config');
     $('cfgLayerHeight').value=Number(c.layerHeight).toFixed(2); $('cfgBaseExposure').value=c.baseExposure; $('cfgRegularExposure').value=c.regularExposure; $('cfgBaseLayers').value=c.baseLayers; $('cfgTransitionLayers').value=c.transitionLayers;
-    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgVatMl').value=c.vatMl; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun; $('cfgWifiEnabled').checked=!!c.wifiEnabled; $('cfgWebDashboardEnabled').checked=!!c.webDashboardEnabled;
+    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgVatMl').value=c.vatMl; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun; $('cfgBootUpdateCheck').checked=!!c.bootUpdateCheck; $('cfgWifiEnabled').checked=!!c.wifiEnabled; $('cfgWebDashboardEnabled').checked=!!c.webDashboardEnabled;
     $('cfgMqttEnabled').checked=!!c.mqttEnabled; $('cfgMqttHost').value=c.mqttHost||''; $('cfgMqttPort').value=c.mqttPort||1883; $('cfgMqttUser').value=c.mqttUser||''; $('cfgMqttPassword').value=''; $('cfgMqttTopic').value=c.mqttTopic||'TinyMaker';
     $('mqttHint').textContent=c.mqttPasswordSet?'Password is saved. Enter a new one only if you want to replace it.':'MQTT password is not set.';
     updateNetworkFields();updateMqttFields();
@@ -1782,6 +1858,7 @@ $('configForm').addEventListener('submit',async e=>{e.preventDefault();try{await
 $('configDefaultsButton').addEventListener('click',async()=>{const keep=$('configDefaultsButton').textContent.indexOf('MQTT')>=0;if(!confirm(keep?'Reset config to defaults and keep MQTT settings?':'Reset config to defaults?'))return;try{await api('/api/config/defaults',{method:'POST'});msg(keep?'Defaults restored. MQTT settings kept.':'Defaults restored.');loadConfig();}catch(e){msg(e.message,true);}});
 $('configMqttResetButton').addEventListener('click',async()=>{if(!confirm('Reset MQTT settings?'))return;try{await api('/api/config/mqtt/defaults',{method:'POST'});msg('MQTT settings reset.');loadConfig();}catch(e){msg(e.message,true);}});
 $('disableDryRunButton').addEventListener('click',async()=>{if(!confirm('Disable dry run mode? Future prints will use the UV LEDs.'))return;try{await api('/api/config/dry-run?enabled=0',{method:'POST'});msg('Dry run disabled.');loadConfig();refreshStatus();}catch(e){msg(e.message,true);}});
+$('updateNowButton').addEventListener('click',startFirmwareUpdate);
 $('cfgWifiEnabled').addEventListener('change',confirmNetworkToggle);
 $('cfgWebDashboardEnabled').addEventListener('change',confirmNetworkToggle);
 $('cfgMqttEnabled').addEventListener('change',updateMqttFields);
@@ -1795,7 +1872,7 @@ $('stopButton').addEventListener('click',()=>printCommand('stop','Stop this prin
 $('modelMlButton').addEventListener('click',()=>modelDetails(enc(selectedModel),true));
 $('modelStartButton').addEventListener('click',()=>startPrint(enc(selectedModel)));
 
-openView(location.hash==='#settings'?'config':'home');refreshStatus();loadConfig();setInterval(tickLocalStatus,1000);setInterval(()=>{refreshStatus();retryPendingPrintCommand();},2000);
+openView(location.hash==='#settings'?'config':'home');refreshStatus();loadConfig();checkFirmwareUpdate();setInterval(tickLocalStatus,1000);setInterval(()=>{refreshStatus();retryPendingPrintCommand();},2000);setInterval(checkFirmwareUpdate,3600000);
 </script>
 )SPA";
   sendRootStyledPage(rootBodyBeforeFw, fw, rootBodyAfterFw);
@@ -1887,6 +1964,59 @@ void otaInstallLatest() {
     delay(1800);
     screen1();
   }
+}
+
+bool otaSetBrowserUpdate(const String &version, const String &url, String &error) {
+  String v = version;
+  String u = url;
+  v.trim();
+  u.trim();
+  if (v.length() == 0 || v.length() > 24) {
+    error = "invalid firmware version";
+    return false;
+  }
+  if (u.length() == 0 || u.length() > 240 || !(u.startsWith("https://") || u.startsWith("http://"))) {
+    error = "invalid firmware url";
+    return false;
+  }
+#ifdef FIRMWARE_VERSION
+  if (cmpSemver(v.c_str(), FIRMWARE_VERSION) <= 0) {
+    error = "firmware is not newer";
+    return false;
+  }
+#endif
+  otaLatestVer = v;
+  otaBinUrl = u;
+  otaState = 3;
+  otaCheckedAt = millis();
+  return true;
+}
+
+void handleApiUpdateInstall() {
+  if (printerBusy()) {
+    sendApiError(409, "printer busy");
+    return;
+  }
+
+  String error;
+  if (!otaSetBrowserUpdate(formString("version", "", 24), formString("url", "", 240), error)) {
+    sendApiError(400, error.c_str());
+    return;
+  }
+
+  sendApiOk("\"started\":true");
+  delay(250); // let the JSON response leave before the updater takes over
+  wakeUiForRemoteAction();
+  otaInstallLatest();
+}
+
+bool network_boot_update_check() {
+  if (!bootUpdateCheckEnabled || WiFi.status() != WL_CONNECTED) return false;
+  netProgressStart("Checking update...", "");
+  otaCheckLatest();
+  if (!otaHasUpdate()) return false;
+  screenBootUpdateAvailable();
+  return true;
 }
 
 // --- WiFi status badge on the main menu (top-right corner, above the icons):
@@ -1997,6 +2127,7 @@ void network_setup() {
   server.on("/api/config/defaults", HTTP_POST, handleApiConfigDefaults);
   server.on("/api/config/mqtt/defaults", HTTP_POST, handleApiConfigMqttDefaults);
   server.on("/api/config/dry-run", HTTP_POST, handleApiConfigDryRun);
+  server.on("/api/update/install", HTTP_POST, handleApiUpdateInstall);
   server.on("/api/print/start", HTTP_POST, handleApiPrintStart);
   server.on("/api/print/pause", HTTP_POST, handleApiPrintPause);
   server.on("/api/print/resume", HTTP_POST, handleApiPrintResume);

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -86,6 +86,7 @@ uint16_t uiTimeoutSecs = 0;         // 0 = never blank the UI screen
 bool uvLedEnabled = true;           // false = dry-run motion/display only
 bool wifiEnabled = true;
 bool webDashboardEnabled = true;
+bool bootUpdateCheckEnabled = true;
 bool wifiTemporarilyEnabled = false;
 bool webDashboardTemporarilyEnabled = false;
 bool mqttEnabled = false;           // Smart Home / MQTT integration scaffold
@@ -111,6 +112,7 @@ void loadDeviceConfig() {
   uvLedEnabled = sysPrefs.getBool("uvLed", true);
   wifiEnabled = sysPrefs.getBool("wifiEnabled", true);
   webDashboardEnabled = sysPrefs.getBool("webDash", true);
+  bootUpdateCheckEnabled = sysPrefs.getBool("bootUpdate", true);
   mqttEnabled = sysPrefs.getBool("mqttEnabled", false);
   mqttHost = sysPrefs.getString("mqttHost", "");
   mqttPort = sysPrefs.getUShort("mqttPort", 1883);
@@ -126,6 +128,7 @@ void saveDeviceConfig() {
   sysPrefs.putBool("uvLed", uvLedEnabled);
   sysPrefs.putBool("wifiEnabled", wifiEnabled);
   sysPrefs.putBool("webDash", webDashboardEnabled);
+  sysPrefs.putBool("bootUpdate", bootUpdateCheckEnabled);
   sysPrefs.putBool("mqttEnabled", mqttEnabled);
   sysPrefs.putString("mqttHost", mqttHost);
   sysPrefs.putUShort("mqttPort", mqttPort);
@@ -144,8 +147,11 @@ const char *otaLatestVerStr();
 int otaVersionState();
 bool otaHasUpdate();
 void otaInstallLatest();
+bool network_boot_update_check();
 void network_service_window(uint16_t durationMs);
 void screen422();   // "install from file" screen (Interface.ino, #if-guarded)
+void screenBootUpdateAvailable();
+void screenBootUpdateDisableConfirm();
 #endif
 
 // ===================================================================================
@@ -291,6 +297,13 @@ void savePrintSettings() {
 bool printerBusy() {
   return screen == 1111 || screen == 1112 || screen == 11111 ||
          screen == 11112 || screen == 11113;
+}
+
+void wakeUiForRemoteAction() {
+  lastUiActivityMs = millis();
+  if (!uiBlanked) return;
+  uiBlanked = false;
+  ((Arduino_TFT *)gfx2)->displayOn();
 }
 
 bool handleUiTimeout() {
@@ -457,6 +470,7 @@ void setup() {
   delay(1000);
   #if ENABLE_NETWORK
   network_setup(); // SLIBBINAS WiFi + upload server (Network.ino)
+  if (network_boot_update_check()) return;
   #endif
   screen1(); // jumps to Main Menu
 }
@@ -646,6 +660,12 @@ void loop() {
       case 423:                 // temporary WiFi prompt -> cancel, back to System > Update
       screen43();
         break;
+      case 424:                 // boot update prompt -> cancel
+      screenBootUpdateDisableConfirm();
+        break;
+      case 425:                 // disable boot update prompt -> no
+      screen1();
+        break;
       #endif
       case 431:
       screen41();
@@ -720,6 +740,12 @@ void loop() {
       #if ENABLE_NETWORK
       case 421:                 // UP on Update screen -> install from file
       screen422();
+        break;
+      case 424:                 // boot update prompt -> cancel
+      screenBootUpdateDisableConfirm();
+        break;
+      case 425:                 // disable boot update prompt -> no
+      screen1();
         break;
       #endif
       case 43:
@@ -1259,6 +1285,14 @@ void loop() {
         break;
       case 421:                 // Update screen -> install latest (self-update)
         if (otaHasUpdate()) otaInstallLatest();
+        break;
+      case 424:                 // boot update prompt -> install latest
+        if (otaHasUpdate()) otaInstallLatest();
+        break;
+      case 425:                 // disable future boot update checks
+        bootUpdateCheckEnabled = false;
+        saveDeviceConfig();
+        screen1();
         break;
       #endif
       case 441:


### PR DESCRIPTION
- Added boot-time firmware update check, enabled by default.
- Added Advanced + web Settings toggle for boot update checks.
- Shows firmware update prompt on the printer when a boot update is available.
- Canceling a boot update asks whether to disable future boot update checks.
- Added browser-side firmware update check on the web dashboard.
- Added `Update now` flow from the dashboard with confirmation.
- Locks/dims the web dashboard while a firmware update is running.
- Disabled `Update now` while printing.
- Wake the printer screen when starting a print from the web UI.
- Wake the printer screen when starting an update from the web UI.
- Reload stale web dashboards if they try to start an already-current update.
- Removed overlapping text from the boot update prompt.