### PR TITLE
Add boot update check

### DIFF
--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -335,7 +335,7 @@ bool advancedMqttConfigured() {
 }
 
 int advancedOptionCount() {
-  int count = 7; // timeout, dry run, VAT refilled, pause, warn, ask, WiFi
+  int count = 8; // timeout, dry run, VAT refilled, pause, warn, ask, WiFi, boot update
   if (wifiEnabled) count++; // web control
   if (wifiEnabled && advancedMqttConfigured()) count++; // MQTT
   return count;
@@ -349,8 +349,9 @@ String advancedLabel(int item) {
   if (item == 5) return "Low resin warn";
   if (item == 6) return "Ask refill";
   if (item == 7) return "WiFi";
-  if (wifiEnabled && item == 8) return "Web control";
-  if (wifiEnabled && advancedMqttConfigured() && item == 9) return "MQTT";
+  if (item == 8) return "Boot update";
+  if (wifiEnabled && item == 9) return "Web control";
+  if (wifiEnabled && advancedMqttConfigured() && item == 10) return "MQTT";
   return "";
 }
 
@@ -365,8 +366,9 @@ String advancedValue(int item) {
   if (item == 5) return String(lowResinThresholdMl) + " ml";
   if (item == 6) return askRefillEnabled ? "On" : "Off";
   if (item == 7) return wifiEnabled ? "On" : "Off";
-  if (wifiEnabled && item == 8) return webDashboardEnabled ? "On" : "Off";
-  if (wifiEnabled && advancedMqttConfigured() && item == 9) return mqttEnabled ? "On" : "Off";
+  if (item == 8) return bootUpdateCheckEnabled ? "On" : "Off";
+  if (wifiEnabled && item == 9) return webDashboardEnabled ? "On" : "Off";
+  if (wifiEnabled && advancedMqttConfigured() && item == 10) return mqttEnabled ? "On" : "Off";
   return "";
 }
 
@@ -432,9 +434,11 @@ void advancedOptionsSelect() {
     } else {
       webDashboardEnabled = true;
     }
-  } else if (wifiEnabled && advanced_item == 8) {
+  } else if (advanced_item == 8) {
+    bootUpdateCheckEnabled = !bootUpdateCheckEnabled;
+  } else if (wifiEnabled && advanced_item == 9) {
     webDashboardEnabled = !webDashboardEnabled;
-  } else if (wifiEnabled && advancedMqttConfigured() && advanced_item == 9) {
+  } else if (wifiEnabled && advancedMqttConfigured() && advanced_item == 10) {
     mqttEnabled = !mqttEnabled;
   }
   saveDeviceConfig();
@@ -568,6 +572,33 @@ void screenUpdateWifiConfirm(){
   gfx2->print("Enable for update?");
   uiButtons("No", "Yes", 0x879F);
   screen = 423;
+}
+
+void screenBootUpdatePrompt(){
+  uiFrame(ORANGE);
+  gfx2->setFont(&FreeSans8pt7b);
+  gfx2->setTextColor(WHITE);
+  gfx2->setTextSize(1);
+  gfx2->setCursor(8, 21);
+  gfx2->print("Update available");
+  gfx2->setCursor(8, 43);
+  gfx2->print("v");
+  gfx2->print(otaLatestVerStr());
+  uiButtons("Later", "Install", 0x879F);
+  screen = 424;
+}
+
+void screenBootUpdateDisablePrompt(){
+  uiFrame(ORANGE);
+  gfx2->setFont(&FreeSans8pt7b);
+  gfx2->setTextColor(WHITE);
+  gfx2->setTextSize(1);
+  gfx2->setCursor(8, 21);
+  gfx2->print("Disable boot");
+  gfx2->setCursor(8, 43);
+  gfx2->print("update check?");
+  uiButtons("No", "Yes", 0x879F);
+  screen = 425;
 }
 #endif
 

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -1404,7 +1404,13 @@ void handleApiStatus() {
   double statusResinMl = busy ? resinUsedMl : 0.0;
 
   String out = "{";
-  out += "\"busy\":";
+  out += "\"firmwareVersion\":\"";
+#ifdef FIRMWARE_VERSION
+  out += jsonEscape(FIRMWARE_VERSION);
+#else
+  out += "unknown";
+#endif
+  out += "\",\"busy\":";
   out += busy ? "true" : "false";
   out += ",\"paused\":";
   out += print_paused ? "true" : "false";
@@ -1809,6 +1815,13 @@ const uploadWithProgress=(fd,hintEl)=>{
   });
 };
 let statusInFlight=false,statusFailCount=0,pendingPrintCmd='',pendingPrintInFlight=false,localPrintStartedAt=0,lpsSynced=false,uploadBusy=false;
+const pageFirmwareVersion=()=>$('fwVersion').textContent.trim();
+const reloadIfFirmwareChanged=s=>{
+  const live=String(s.firmwareVersion||'').trim(),page=pageFirmwareVersion();
+  if(!live||!page||live===page)return false;
+  location.replace('/?fw='+encodeURIComponent(live)+'&r='+Date.now());
+  return true;
+};
 const openView=view=>{
   show('homeView',view==='home');
   show('modelPanel',view==='model');
@@ -1893,6 +1906,7 @@ const refreshStatus=async()=>{
   statusInFlight=true;
   try{
     const s=await api('/api/status',null,30000);
+    if(reloadIfFirmwareChanged(s))return;
     statusFailCount=0;
     applyStatus(s);
     if(!pendingPrintCmd)msg('',false);

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -923,6 +923,8 @@ String configJson() {
   out += wifiEnabled ? "true" : "false";
   out += ",\"webDashboardEnabled\":";
   out += webDashboardEnabled ? "true" : "false";
+  out += ",\"bootUpdateCheck\":";
+  out += bootUpdateCheckEnabled ? "true" : "false";
   out += ",\"mqttEnabled\":";
   out += mqttEnabled ? "true" : "false";
   out += ",\"mqttConfigured\":";
@@ -961,6 +963,7 @@ void applyConfigRequest() {
   uvLedEnabled = !server.hasArg("dry_run");
   wifiEnabled = server.hasArg("wifi_enabled");
   webDashboardEnabled = wifiEnabled && server.hasArg("web_dashboard_enabled");
+  bootUpdateCheckEnabled = server.hasArg("boot_update_check");
   mqttEnabled = server.hasArg("mqtt_enabled");
   if (!wifiEnabled) mqttEnabled = false;
   mqttHost = formString("mqtt_host", mqttHost, 80);
@@ -1007,6 +1010,7 @@ void resetWebConfigToDefaults() {
   uvLedEnabled = true;
   wifiEnabled = true;
   webDashboardEnabled = true;
+  bootUpdateCheckEnabled = true;
   saveDeviceConfig();
 }
 
@@ -1693,6 +1697,7 @@ void handleRootPage() {
     <label class='check'><input name='dry_run' id='cfgDryRun' type='checkbox' value='1'><span>Dry run mode</span></label>
     <label class='check'><input name='wifi_enabled' id='cfgWifiEnabled' type='checkbox' value='1'><span>WiFi</span></label>
     <label class='check'><input name='web_dashboard_enabled' id='cfgWebDashboardEnabled' type='checkbox' value='1'><span>Web control (browser actions)</span></label>
+    <label class='check spanAll'><input name='boot_update_check' id='cfgBootUpdateCheck' type='checkbox' value='1'><span>Boot update check</span></label>
     <label class='check spanAll'><input name='mqtt_enabled' id='cfgMqttEnabled' type='checkbox' value='1'><span>Enable MQTT? (SmartHome integration)</span></label>
     <div id='mqttFields' class='spanAll hidden'>
       <div class='configGrid'>
@@ -1823,7 +1828,7 @@ const applyStatus=s=>{
     if(!s.busy){localPrintStartedAt=0;lpsSynced=false;}
     if((pendingPrintCmd==='stop'&&s.stopping)||(pendingPrintCmd==='pause'&&(s.pausing||s.paused))||(pendingPrintCmd==='resume'&&s.resuming))pendingPrintCmd='';
     setText('stateValue',s.state); setText('wifiValue',s.wifiText); setText('ipValue',s.ip); setText('lifetimeValue',s.lifetimePrintTime); setText('sdValue',s.sdText);
-    if(typeof s.freeHeap==='number'){const u=s.uptimeSecs||0,ud=Math.floor(u/86400),uh=Math.floor(u%86400/3600),um=Math.floor(u%3600/60);setText('debugValue','heap '+Math.round(s.freeHeap/1024)+'k · min '+Math.round(s.minFreeHeap/1024)+'k · blk '+Math.round(s.maxAllocHeap/1024)+'k · up '+(ud?ud+'d ':'')+uh+'h '+um+'m');}
+    if(typeof s.freeHeap==='number'){const u=s.uptimeSecs||0,ud=Math.floor(u/86400),uh=Math.floor(u%86400/3600),um=Math.floor(u%3600/60);setText('debugValue','heap '+Math.round(s.freeHeap/1024)+'k | min '+Math.round(s.minFreeHeap/1024)+'k | blk '+Math.round(s.maxAllocHeap/1024)+'k | up '+(ud?ud+'d ':'')+uh+'h '+um+'m');}
     const wb=$('wifiBars').children,wr=s.wifiRssi,wn=(wr&&wr<0)?(wr>-60?3:(wr>-75?2:1)):0;for(let i=0;i<3;i++)wb[i].classList.toggle('on',i<wn);
     setText('layerValue',s.layerText); setText('resinValue',s.resinText); setText('runValue',s.runTime); setText('remainingValue',s.remainingTime);
     setText('vatValue',s.vatLow?s.vatText+' (low!)':s.vatText); $('vatValue').style.color=s.vatLow?'#ff6b5f':'';
@@ -2110,7 +2115,7 @@ const loadConfig=async()=>{
   try{
     const c=await api('/api/config');
     $('cfgLayerHeight').value=Number(c.layerHeight).toFixed(2); $('cfgBaseExposure').value=c.baseExposure; $('cfgRegularExposure').value=c.regularExposure; $('cfgBaseLayers').value=c.baseLayers; $('cfgTransitionLayers').value=c.transitionLayers;
-    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgVatMl').value=c.vatMl; $('cfgLowResinMl').value=c.lowResinMl; $('cfgLowResinPause').checked=!!c.lowResinPause; $('cfgAskRefill').checked=!!c.askRefill; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun; $('cfgWifiEnabled').checked=!!c.wifiEnabled; $('cfgWebDashboardEnabled').checked=!!c.webDashboardEnabled;
+    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgVatMl').value=c.vatMl; $('cfgLowResinMl').value=c.lowResinMl; $('cfgLowResinPause').checked=!!c.lowResinPause; $('cfgAskRefill').checked=!!c.askRefill; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun; $('cfgWifiEnabled').checked=!!c.wifiEnabled; $('cfgWebDashboardEnabled').checked=!!c.webDashboardEnabled; $('cfgBootUpdateCheck').checked=!!c.bootUpdateCheck;
     $('cfgMqttEnabled').checked=!!c.mqttEnabled; $('cfgMqttHost').value=c.mqttHost||''; $('cfgMqttPort').value=c.mqttPort||1883; $('cfgMqttUser').value=c.mqttUser||''; $('cfgMqttPassword').value=''; $('cfgMqttTopic').value=c.mqttTopic||'TinyMaker';
     $('mqttHint').textContent=c.mqttPasswordSet?'Password is saved. Enter a new one only if you want to replace it.':'MQTT password is not set.';
     updateNetworkFields();updateMqttFields();
@@ -2252,7 +2257,7 @@ unsigned long otaCheckedAt = 0;   // millis() of the last successful check
 // Blocking (a few seconds); the caller should show "checking..." first.
 // A successful result is cached for 5 min so reopening the Update screen
 // (or bouncing to/from "Install from file") does not re-block the UI.
-void otaCheckLatest() {
+void otaCheckLatest(uint16_t timeoutMs) {
   if ((otaState == 2 || otaState == 3) && millis() - otaCheckedAt < 300000UL)
     return;                        // recent successful check - reuse it
   otaState = 1;
@@ -2263,8 +2268,8 @@ void otaCheckLatest() {
   WiFiClientSecure client;
   client.setInsecure();            // home LAN: skip cert validation
   HTTPClient https;
-  https.setConnectTimeout(6000);
-  https.setTimeout(6000);
+  https.setConnectTimeout(timeoutMs);
+  https.setTimeout(timeoutMs);
   if (!https.begin(client, OTA_VERSION_URL)) { otaState = 4; return; }
 
   int code = https.GET();
@@ -2291,9 +2296,17 @@ void otaCheckLatest() {
   https.end();
 }
 
+void otaCheckLatest() { otaCheckLatest(6000); }
+
 const char *otaLatestVerStr() { return otaLatestVer.c_str(); }
 int  otaVersionState()        { return otaState; }
 bool otaHasUpdate()           { return otaState == 3 && otaBinUrl.length() > 0; }
+
+void otaBootCheckMaybePrompt() {
+  if (!bootUpdateCheckEnabled || WiFi.status() != WL_CONNECTED) return;
+  otaCheckLatest(2500);
+  if (otaHasUpdate()) screenBootUpdatePrompt();
+}
 
 // Download a firmware image over HTTPS and flash it. Shows progress on the
 // LCD; reboots on success. Shared by "Install latest" and the version picker.
@@ -2537,7 +2550,10 @@ void network_setup() {
 
   String ip = "IP: " + WiFi.localIP().toString();
   netMessage("WiFi connected", ip.c_str());
-  delay(1500);
+  delay(700);
+  otaBootCheckMaybePrompt();
+  if (screen == 424) return;
+  delay(800);
 }
 
 // ===================================================================================

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -101,6 +101,7 @@ uint16_t uiTimeoutSecs = 0;         // 0 = never blank the UI screen
 bool uvLedEnabled = true;           // false = dry-run motion/display only
 bool wifiEnabled = true;
 bool webDashboardEnabled = true;
+bool bootUpdateCheckEnabled = true;
 bool wifiTemporarilyEnabled = false;
 bool webDashboardTemporarilyEnabled = false;
 bool mqttEnabled = false;           // Smart Home / MQTT integration scaffold
@@ -126,6 +127,7 @@ void loadDeviceConfig() {
   uvLedEnabled = sysPrefs.getBool("uvLed", true);
   wifiEnabled = sysPrefs.getBool("wifiEnabled", true);
   webDashboardEnabled = sysPrefs.getBool("webDash", true);
+  bootUpdateCheckEnabled = sysPrefs.getBool("bootUpdChk", true);
   mqttEnabled = sysPrefs.getBool("mqttEnabled", false);
   mqttHost = sysPrefs.getString("mqttHost", "");
   mqttPort = sysPrefs.getUShort("mqttPort", 1883);
@@ -147,6 +149,7 @@ void saveDeviceConfig() {
   sysPrefs.putBool("uvLed", uvLedEnabled);
   sysPrefs.putBool("wifiEnabled", wifiEnabled);
   sysPrefs.putBool("webDash", webDashboardEnabled);
+  sysPrefs.putBool("bootUpdChk", bootUpdateCheckEnabled);
   sysPrefs.putBool("mqttEnabled", mqttEnabled);
   sysPrefs.putString("mqttHost", mqttHost);
   sysPrefs.putUShort("mqttPort", mqttPort);
@@ -172,12 +175,15 @@ void saveVatRemaining() {
 // in Interface.ino and loop() can call them across the #if boundary
 // (auto-prototypes are not generated for functions inside #if blocks).
 void otaCheckLatest();
+void otaCheckLatest(uint16_t timeoutMs);
 const char *otaLatestVerStr();
 int otaVersionState();
 bool otaHasUpdate();
 void otaInstallLatest();
 void network_service_window(uint16_t durationMs);
 void screen422();   // "install from file" screen (Interface.ino, #if-guarded)
+void screenBootUpdatePrompt();
+void screenBootUpdateDisablePrompt();
 #endif
 
 // ===================================================================================
@@ -515,6 +521,7 @@ void setup() {
   delay(1000);
   #if ENABLE_NETWORK
   network_setup(); // SLIBBINAS WiFi + upload server (Network.ino)
+  if (screen == 424 || screen == 425) return;
   #endif
   screen1(); // jumps to Main Menu
 }
@@ -712,6 +719,12 @@ void loop() {
         break;
       case 423:                 // temporary WiFi prompt -> cancel, back to System > Update
       screen43();
+        break;
+      case 424:                 // boot update prompt -> Later
+        screenBootUpdateDisablePrompt();
+        break;
+      case 425:                 // keep boot update check enabled
+        screen1();
         break;
       #endif
       case 431:
@@ -1397,6 +1410,14 @@ void loop() {
         webDashboardTemporarilyEnabled = true;
         network_setup();
         screen421();
+        break;
+      case 424:                 // boot update prompt -> Install
+        if (otaHasUpdate()) otaInstallLatest();
+        break;
+      case 425:                 // disable boot update check
+        bootUpdateCheckEnabled = false;
+        saveDeviceConfig();
+        screen1();
         break;
       case 421:                 // Update screen -> install latest (self-update)
         if (otaHasUpdate()) otaInstallLatest();


### PR DESCRIPTION
Checks for a newer firmware shortly after WiFi connects at boot and prompts on the LCD with Install/Later when an update is available.

Adds a persisted Boot update setting in Advanced and the web Settings API, defaulting on and reset with other device defaults.