### PR TITLE
feat: downloadable boot animations (library + selector + install/manage API)

### DIFF
--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -104,11 +104,128 @@ void netProgressBar(int step, int total) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// ---- Boot-animation library (/bootanim/*.tmb) -----------------------------
+// The printer keeps a folder of named TMB1 animations; bootAnimName selects the
+// active one ("" = built-in splash). Kept out of the ENABLE_NETWORK block so the
+// on-device menu + playback work in the network-free build too; the /api/boot-anim
+// endpoints and dashboard card live in Network.ino.
+#define BOOTANIM_DIR "/bootanim"
+
+// Keep only [a-z0-9-_], lowercase, <=40 chars; never empty (used as a filename).
+String sanitizeAnimName(const String &in) {
+  String out;
+  for (size_t i = 0; i < in.length() && out.length() < 40; i++) {
+    char c = in[i];
+    if (c >= 'A' && c <= 'Z') c += 32;
+    if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_') out += c;
+  }
+  return out.length() ? out : String("downloaded");
+}
+
+// Fill out[] with the .tmb basenames (no extension) in /bootanim; returns count.
+int listBootAnims(String out[], int maxN) {
+  int count = 0;
+  File dir = SD.open(BOOTANIM_DIR);
+  if (!dir) return 0;
+  File e;
+  while (count < maxN && (e = dir.openNextFile())) {
+    char nm[64];
+    e.getName(nm, sizeof(nm));
+    bool isDir = e.isDirectory();
+    e.close();
+    if (isDir) continue;
+    String s = nm, lower = nm;
+    lower.toLowerCase();
+    if (!lower.endsWith(".tmb")) continue;
+    out[count++] = s.substring(0, s.length() - 4);
+  }
+  dir.close();
+  return count;
+}
+
+bool bootAnimExists(const String &name) {
+  if (name.length() == 0) return false;
+  String path = String(BOOTANIM_DIR) + "/" + name + ".tmb";
+  File f = SD.open(path.c_str());
+  bool ok = (bool)f;
+  if (f) f.close();
+  return ok;
+}
+
+// "cure-line" -> "Cure Line" for the menu value / dashboard label.
+String bootAnimDisplay(const String &name) {
+  if (name.length() == 0) return "Default";
+  String out;
+  bool up = true;
+  for (size_t i = 0; i < name.length(); i++) {
+    char c = name[i];
+    if (c == '-' || c == '_') { out += ' '; up = true; }
+    else if (up) { out += (char)toupper(c); up = false; }
+    else out += c;
+  }
+  return out;
+}
+
+// Advanced-menu cycle order: Default ("") -> each file -> back to Default.
+String nextBootAnim(const String &current) {
+  String names[24];
+  int n = listBootAnims(names, 24);
+  if (current.length() == 0) return n > 0 ? names[0] : String("");
+  for (int i = 0; i < n; i++)
+    if (names[i] == current) return (i + 1 < n) ? names[i + 1] : String("");
+  return "";  // current was deleted -> back to Default
+}
+
+// Play the selected boot animation from the /bootanim library. Returns true if
+// it played, false to fall back to the built-in splash. Reads the selection
+// directly because loadDeviceConfig() runs after screen0() at boot.
+bool playBootAnimFromSd() {
+  sysPrefs.begin("tinymaker", true);
+  String name = sysPrefs.getString("bootAnimName", "");
+  sysPrefs.end();
+  if (name.length() == 0) return false;
+
+  String path = "/bootanim/" + name + ".tmb";
+  File f = SD.open(path.c_str());
+  if (!f) return false;
+
+  uint8_t hdr[12];
+  if (f.read(hdr, 12) != 12 ||
+      hdr[0] != 'T' || hdr[1] != 'M' || hdr[2] != 'B' || hdr[3] != '1') {
+    f.close();
+    return false;
+  }
+  uint16_t w   = hdr[4]  | (hdr[5]  << 8);
+  uint16_t h   = hdr[6]  | (hdr[7]  << 8);
+  uint16_t n   = hdr[8]  | (hdr[9]  << 8);
+  uint16_t fps = hdr[10] | (hdr[11] << 8);
+  if (w == 0 || w > 160 || h == 0 || h > 80 || n == 0) { f.close(); return false; }
+
+  size_t frameBytes = (size_t)w * h * 2;
+  uint16_t *frame = (uint16_t *)malloc(frameBytes);
+  if (!frame) { f.close(); return false; }
+
+  int frameDelay = fps > 0 ? (1000 / fps) : 80;
+  int16_t ox = (160 - w) / 2, oy = (80 - h) / 2;
+  gfx2->fillScreen(BLACK);
+  for (uint16_t i = 0; i < n; i++) {
+    if (f.read((uint8_t *)frame, frameBytes) != (int)frameBytes) break;
+    gfx2->draw16bitRGBBitmap(ox, oy, frame, w, h);
+    delay(frameDelay);
+  }
+  free(frame);
+  f.close();
+  return true;
+}
+
 /**
- * @brief Screen 0: Welcome Screen
- * Displays "Hello, World!" message on startup.
+ * @brief Screen 0: Boot splash
+ * Plays the selected animation from the /bootanim library when one is chosen in
+ * Advanced; otherwise the built-in rising "Tiny Maker" wordmark.
  */
 void screen0(){
+  if (playBootAnimFromSd()) return;
+
   gfx2->fillScreen(BLACK);
   gfx2->setFont(&FreeSans8pt7b);
   gfx2->setCursor(5, 74);
@@ -122,7 +239,7 @@ void screen0(){
   for (int i = 0; i < 40; i++) {
     gfx2->setCursor(40, i);
     gfx2->setTextColor(ORANGE);
-    gfx2->println("Tiny Maker"); 
+    gfx2->println("Tiny Maker");
     delay(30);
     gfx2->setCursor(40, i);
     gfx2->setTextColor(BLACK);
@@ -130,7 +247,7 @@ void screen0(){
   }
   gfx2->setCursor(40, 40);
   gfx2->setTextColor(ORANGE);
-  gfx2->println("Tiny Maker"); 
+  gfx2->println("Tiny Maker");
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -335,7 +452,7 @@ bool advancedMqttConfigured() {
 }
 
 int advancedOptionCount() {
-  int count = 9; // timeout, dry run, VAT refilled, pause, warn, ask, WiFi, boot update, exposure test
+  int count = 10; // ...exposure test, boot animation
   if (wifiEnabled) count++; // web control
   if (wifiEnabled && advancedMqttConfigured()) count++; // MQTT
   return count;
@@ -351,8 +468,9 @@ String advancedLabel(int item) {
   if (item == 7) return "WiFi";
   if (item == 8) return "Boot update";
   if (item == 9) return "Exposure test";
-  if (wifiEnabled && item == 10) return "Web control";
-  if (wifiEnabled && advancedMqttConfigured() && item == 11) return "MQTT";
+  if (item == 10) return "Boot animation";
+  if (wifiEnabled && item == 11) return "Web control";
+  if (wifiEnabled && advancedMqttConfigured() && item == 12) return "MQTT";
   return "";
 }
 
@@ -369,8 +487,10 @@ String advancedValue(int item) {
   if (item == 7) return wifiEnabled ? "On" : "Off";
   if (item == 8) return bootUpdateCheckEnabled ? "On" : "Off";
   if (item == 9) return String(expTestBarSecs(1)) + "-" + String(expTestBarSecs(8)) + "s strip";
-  if (wifiEnabled && item == 10) return webDashboardEnabled ? "On" : "Off";
-  if (wifiEnabled && advancedMqttConfigured() && item == 11) return mqttEnabled ? "On" : "Off";
+  if (item == 10) return bootAnimName.length() == 0 ? "Default"
+    : (bootAnimExists(bootAnimName) ? bootAnimDisplay(bootAnimName) : bootAnimDisplay(bootAnimName) + " (missing)");
+  if (wifiEnabled && item == 11) return webDashboardEnabled ? "On" : "Off";
+  if (wifiEnabled && advancedMqttConfigured() && item == 12) return mqttEnabled ? "On" : "Off";
   return "";
 }
 
@@ -441,9 +561,11 @@ void advancedOptionsSelect() {
   } else if (advanced_item == 9) {
     screenExpTestIntro();       // action item: opens the exposure test flow
     return;
-  } else if (wifiEnabled && advanced_item == 10) {
+  } else if (advanced_item == 10) {
+    bootAnimName = nextBootAnim(bootAnimName);  // cycle Default -> each installed animation
+  } else if (wifiEnabled && advanced_item == 11) {
     webDashboardEnabled = !webDashboardEnabled;
-  } else if (wifiEnabled && advancedMqttConfigured() && advanced_item == 11) {
+  } else if (wifiEnabled && advancedMqttConfigured() && advanced_item == 12) {
     mqttEnabled = !mqttEnabled;
   }
   saveDeviceConfig();

--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -208,10 +208,19 @@ bool playBootAnimFromSd() {
   int frameDelay = fps > 0 ? (1000 / fps) : 80;
   int16_t ox = (160 - w) / 2, oy = (80 - h) / 2;
   gfx2->fillScreen(BLACK);
-  for (uint16_t i = 0; i < n; i++) {
+  // These files can arrive from a community site, so frameCount (uint16, up to
+  // 65535) is untrusted: cap total frames and elapsed time so a corrupt/oversized
+  // animation can't hold boot hostage, and let Back skip it immediately.
+  const uint16_t MAX_FRAMES = 250;
+  const uint32_t MAX_MS     = 10000;
+  uint16_t limit = n < MAX_FRAMES ? n : MAX_FRAMES;
+  uint32_t animStart = millis();
+  for (uint16_t i = 0; i < limit; i++) {
     if (f.read((uint8_t *)frame, frameBytes) != (int)frameBytes) break;
     gfx2->draw16bitRGBBitmap(ox, oy, frame, w, h);
     delay(frameDelay);
+    if (digitalRead(buttonBack) == LOW) break;   // user skip
+    if (millis() - animStart > MAX_MS) break;     // hard time budget
   }
   free(frame);
   f.close();

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -2004,6 +2004,12 @@ void handleRootPage() {
   <div id='configHint' class='hint'>Config locks automatically while printing.</div>
 </section>
 
+<section id='bootAnimView' class='card hidden'>
+  <h2>Boot animation</h2>
+  <div id='bootAnimList'></div>
+  <div id='bootAnimHint' class='hint'>Choose which animation plays at power-on. Send more from the community site; Delete removes one from the SD card.</div>
+</section>
+
 <section id='updateView' class='card hidden'>
   <h2>Firmware update</h2>
   <div class='grid'>
@@ -2117,11 +2123,69 @@ const reloadIfFirmwareChanged=s=>{
   location.replace('/?fw='+encodeURIComponent(live)+'&r='+Date.now());
   return true;
 };
+const loadBootAnims=async()=>{
+  const wrap=$('bootAnimList');
+  try{
+    const d=await api('/api/boot-anim');
+    const sel=d.selected||'';
+    wrap.innerHTML='';
+    wrap.style.cssText='display:flex;flex-direction:column;gap:2px;margin:8px 0 4px';
+    const rows=[{name:'',display:'Default (built-in)'}].concat(d.animations||[]);
+    rows.forEach(a=>{
+      const active=sel===a.name;
+      const row=document.createElement('div');
+      row.style.cssText='display:flex;align-items:center;gap:12px;padding:9px 10px;border-radius:8px'+(active?';background:rgba(255,138,30,.09)':'');
+
+      const pick=document.createElement('button');
+      pick.type='button';
+      pick.style.cssText='flex:1;min-width:0;display:flex;align-items:center;gap:11px;background:none;border:0;cursor:pointer;padding:0;margin:0;text-align:left';
+
+      const dot=document.createElement('span');
+      dot.style.cssText='flex:0 0 auto;width:13px;height:13px;border-radius:50%;border:2px solid '+(active?'#ff8a1e':'#6a6a72')+';background:'+(active?'#ff8a1e':'transparent')+';box-shadow:'+(active?'inset 0 0 0 2px #1e1e23':'none');
+
+      const label=document.createElement('span');
+      label.style.cssText='min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:'+(active?'#ff8a1e':'#e9e9ec')+';font-weight:'+(active?'600':'500');
+      label.textContent=a.display;
+
+      pick.appendChild(dot);pick.appendChild(label);
+      if(a.name){
+        const meta=document.createElement('span');
+        meta.style.cssText='flex:0 0 auto;color:#8a8a92;font-size:12px';
+        meta.textContent=formatBytes(a.sizeBytes);
+        pick.appendChild(meta);
+      }
+      pick.addEventListener('click',()=>selectBootAnim(a.name));
+      row.appendChild(pick);
+
+      if(a.name){
+        const del=document.createElement('button');
+        del.type='button';
+        del.style.cssText='flex:0 0 auto;width:auto;white-space:nowrap;margin:0;padding:5px 13px;font-size:12.5px;background:transparent;border:1px solid #44343a;color:#e08a92;border-radius:7px;cursor:pointer';
+        del.textContent='Delete';
+        del.addEventListener('click',()=>deleteBootAnim(a.name,a.display));
+        row.appendChild(del);
+      }
+      wrap.appendChild(row);
+    });
+  }catch(e){$('bootAnimHint').textContent=e.message;}
+};
+const selectBootAnim=async name=>{
+  try{await api('/api/boot-anim/select',{method:'POST',body:new URLSearchParams({name})});
+    msg(name?'Boot animation set. Reboot to see it.':'Using the built-in boot animation.');loadBootAnims();}
+  catch(e){msg(e.message,true);}
+};
+const deleteBootAnim=async(name,display)=>{
+  if(!confirm('Delete "'+display+'" from the printer?'))return;
+  try{await api('/api/boot-anim/delete',{method:'POST',body:new URLSearchParams({name})});
+    msg('Deleted "'+display+'".');loadBootAnims();}
+  catch(e){msg(e.message,true);}
+};
 const openView=view=>{
   show('homeView',view==='home');
   show('modelPanel',view==='model');
   show('connectView',view==='connect');
   show('configView',view==='config');
+  show('bootAnimView',view==='config');
   show('updateView',view==='update');
   $('homeViewButton').classList.toggle('active',view==='home'||view==='model');
   $('connectViewButton').classList.toggle('active',view==='connect');
@@ -2129,7 +2193,7 @@ const openView=view=>{
   $('updateViewButton').classList.toggle('active',view==='update');
   if(view==='home')loadFiles();
   if(view==='connect')loadConfig().then(()=>loadConnectModels());
-  if(view==='config')loadConfig();
+  if(view==='config'){loadConfig();loadBootAnims();}
   if(view==='update')loadUpdate();
 };
 
@@ -2976,6 +3040,156 @@ void drawWifiBadge() {
   gfx2->fillRect(154, 2, 2, 9, c);   // tall bar (ends 2 px from the edge)
 }
 
+// Boot-animation install: the printer pulls a TMB1 file from a community URL and
+// stores it in the /bootanim library, then makes it the active boot animation.
+// CORS header so the cross-origin "Send to printer" page can read our reply.
+//   POST /api/boot-anim/install   body: url=<http/https .tmb url>&name=<slug>
+void handleApiBootAnimInstall() {
+  server.sendHeader("Access-Control-Allow-Origin", "*");
+
+  if (rejectIfWebControlOff()) return;                       // 403 when web control off
+  if (printerBusy())   { sendApiError(409, "printer busy"); return; }
+  if (!sdCardReady())  { sendApiError(503, "sd card unavailable"); return; }
+  if (WiFi.status() != WL_CONNECTED) { sendApiError(503, "wifi not connected"); return; }
+
+  String url = server.arg("url");
+  url.trim();
+  if (!(url.startsWith("http://") || url.startsWith("https://"))) {
+    sendApiError(400, "missing or invalid url");
+    return;
+  }
+
+  String slug = sanitizeAnimName(server.arg("name"));
+
+  netProgressStart("Boot animation:", "downloading");
+
+  HTTPClient http;
+  WiFiClient plain;
+  WiFiClientSecure secure;
+  bool ok;
+  if (url.startsWith("https://")) { secure.setInsecure(); ok = http.begin(secure, url); }
+  else                            { ok = http.begin(plain, url); }
+  if (!ok) { sendApiError(502, "could not start download"); netMessage("Boot animation", "download failed"); delay(1200); screen1(); return; }
+
+  http.setTimeout(12000);
+  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+  int code = http.GET();
+  if (code != HTTP_CODE_OK) {
+    http.end();
+    sendApiError(502, (String("download HTTP ") + code).c_str());
+    netMessage("Boot animation", "download failed");
+    delay(1200); screen1();
+    return;
+  }
+
+  WiFiClient *stream = http.getStreamPtr();
+  int remaining = http.getSize();  // -1 when the length is unknown (chunked)
+
+  // Read the first chunk and verify the TMB1 magic BEFORE we open the target file,
+  // so a bad download can't clobber an existing animation of the same name.
+  uint8_t buf[1024];
+  uint32_t waitStart = millis();
+  int first = 0;
+  while (first < 4 && millis() - waitStart < 12000) {
+    if (stream->available()) { first = stream->readBytes(buf, sizeof(buf)); break; }
+    delay(2);
+  }
+  if (first < 12 || buf[0] != 'T' || buf[1] != 'M' || buf[2] != 'B' || buf[3] != '1') {
+    http.end();
+    sendApiError(422, "not a TMB1 animation");
+    netMessage("Boot animation", "invalid file");
+    delay(1200); screen1();
+    return;
+  }
+
+  SD.mkdir(BOOTANIM_DIR);
+  String savePath = String(BOOTANIM_DIR) + "/" + slug + ".tmb";
+  SD.remove(savePath.c_str());
+  File out = SD.open(savePath.c_str(), FILE_WRITE);
+  if (!out) { http.end(); sendApiError(500, "sd write failed"); netMessage("Boot animation", "SD write failed"); delay(1200); screen1(); return; }
+
+  size_t total = 0;
+  out.write(buf, first);
+  total += first;
+  if (remaining > 0) remaining -= first;
+
+  uint32_t lastDraw = 0;
+  while (http.connected() && remaining != 0) {
+    size_t avail = stream->available();
+    if (avail) {
+      int n = stream->readBytes(buf, avail > sizeof(buf) ? sizeof(buf) : avail);
+      if (n <= 0) break;
+      out.write(buf, n);
+      total += n;
+      if (remaining > 0) { remaining -= n; if (remaining == 0) break; }
+      if (millis() - lastDraw > 120) {       // size may be unknown; bar wraps every 256 KB
+        lastDraw = millis();
+        int w = (int)((total % 262144L) * 136L / 262144L);
+        gfx2->fillRect(12, 50, 136, 12, BLACK);
+        gfx2->fillRect(12, 50, w, 12, ORANGE);
+      }
+    } else {
+      if (!http.connected()) break;
+      delay(2);
+    }
+  }
+  out.close();
+  http.end();
+
+  bootAnimName = slug;          // installed animation becomes the active one
+  saveDeviceConfig();
+  sendApiOk("\"bytes\":" + String((unsigned long)total) + ",\"name\":\"" + jsonEscape(slug) + "\"");
+  netMessage("Boot animation:", bootAnimDisplay(slug).c_str());
+  delay(1200);
+  screen1();
+}
+
+// GET /api/boot-anim - list installed animations + which one is active.
+void handleApiBootAnimList() {
+  if (printerBusy())  { sendApiError(409, "printer busy"); return; }
+  if (!sdCardReady()) { sendApiError(503, "sd card unavailable"); return; }
+  String names[24];
+  int n = listBootAnims(names, 24);
+  String out = "{\"selected\":\"" + jsonEscape(bootAnimName) + "\",\"animations\":[";
+  for (int i = 0; i < n; i++) {
+    if (i) out += ",";
+    String path = String(BOOTANIM_DIR) + "/" + names[i] + ".tmb";
+    File f = SD.open(path.c_str());
+    long sz = f ? (long)f.size() : 0;
+    if (f) f.close();
+    out += "{\"name\":\"" + jsonEscape(names[i]) + "\",\"display\":\"" +
+           jsonEscape(bootAnimDisplay(names[i])) + "\",\"sizeBytes\":" + String(sz) + "}";
+  }
+  out += "]}";
+  server.send(200, "application/json", out);
+}
+
+// POST /api/boot-anim/select  body: name=<slug|empty>  ("" = built-in Default)
+void handleApiBootAnimSelect() {
+  if (rejectIfWebControlOff()) return;
+  if (printerBusy()) { sendApiError(409, "printer busy"); return; }
+  String name = server.arg("name");
+  name.trim();
+  if (name.length() > 0 && !bootAnimExists(name)) { sendApiError(404, "animation not found"); return; }
+  bootAnimName = name;
+  saveDeviceConfig();
+  sendApiOk("\"selected\":\"" + jsonEscape(bootAnimName) + "\"");
+}
+
+// POST /api/boot-anim/delete  body: name=<slug>
+void handleApiBootAnimDelete() {
+  if (rejectIfWebControlOff()) return;
+  if (printerBusy())  { sendApiError(409, "printer busy"); return; }
+  if (!sdCardReady()) { sendApiError(503, "sd card unavailable"); return; }
+  String name = server.arg("name");
+  name.trim();
+  if (name.length() == 0 || !bootAnimExists(name)) { sendApiError(404, "animation not found"); return; }
+  String path = String(BOOTANIM_DIR) + "/" + name + ".tmb";
+  SD.remove(path.c_str());
+  if (bootAnimName == name) { bootAnimName = ""; saveDeviceConfig(); }  // fall back to Default
+  sendApiOk("");
+}
+
 void network_setup() {
   if (!networkRuntimeEnabled()) {
     WiFi.mode(WIFI_OFF);
@@ -3087,6 +3301,16 @@ void network_setup() {
   server.on("/api/print/pause", HTTP_POST, handleApiPrintPause);
   server.on("/api/print/resume", HTTP_POST, handleApiPrintResume);
   server.on("/api/print/stop", HTTP_POST, handleApiPrintStop);
+  server.on("/api/boot-anim", HTTP_GET, handleApiBootAnimList);
+  server.on("/api/boot-anim/select", HTTP_POST, handleApiBootAnimSelect);
+  server.on("/api/boot-anim/delete", HTTP_POST, handleApiBootAnimDelete);
+  server.on("/api/boot-anim/install", HTTP_POST, handleApiBootAnimInstall);
+  server.on("/api/boot-anim/install", HTTP_OPTIONS, []() {   // CORS preflight
+    server.sendHeader("Access-Control-Allow-Origin", "*");
+    server.sendHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    server.sendHeader("Access-Control-Allow-Headers", "Content-Type");
+    server.send(204);
+  });
   server.on("/api/files/local", HTTP_POST, finishUpload, handleUploadData);
 
   // Plain endpoint for curl / UVtools testing:

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -2175,7 +2175,7 @@ const selectBootAnim=async name=>{
   catch(e){msg(e.message,true);}
 };
 const deleteBootAnim=async(name,display)=>{
-  if(!confirm('Delete "'+display+'" from the printer?'))return;
+  if(!await uiConfirm('Delete "'+display+'" from the printer?',{danger:true}))return;
   try{await api('/api/boot-anim/delete',{method:'POST',body:new URLSearchParams({name})});
     msg('Deleted "'+display+'".');loadBootAnims();}
   catch(e){msg(e.message,true);}
@@ -3090,9 +3090,17 @@ void handleApiBootAnimInstall() {
   uint8_t buf[1024];
   uint32_t waitStart = millis();
   int first = 0;
-  while (first < 4 && millis() - waitStart < 12000) {
-    if (stream->available()) { first = stream->readBytes(buf, sizeof(buf)); break; }
-    delay(2);
+  // Accumulate until we have the full 12-byte header (or time out): a slow server
+  // can deliver the magic across several small segments, and breaking after the
+  // first read would false-reject a valid TMB1 file.
+  while (first < 12 && millis() - waitStart < 12000) {
+    size_t avail = stream->available();
+    if (avail) {
+      int n = stream->readBytes(buf + first, avail > sizeof(buf) - first ? sizeof(buf) - first : avail);
+      if (n > 0) first += n;
+    } else {
+      delay(2);
+    }
   }
   if (first < 12 || buf[0] != 'T' || buf[1] != 'M' || buf[2] != 'B' || buf[3] != '1') {
     http.end();
@@ -3108,6 +3116,8 @@ void handleApiBootAnimInstall() {
   File out = SD.open(savePath.c_str(), FILE_WRITE);
   if (!out) { http.end(); sendApiError(500, "sd write failed"); netMessage("Boot animation", "SD write failed"); delay(1200); screen1(); return; }
 
+  const size_t MAX_ANIM_BYTES = 8UL * 1024 * 1024;   // reject runaway/chunked downloads
+  bool tooBig = false;
   size_t total = 0;
   out.write(buf, first);
   total += first;
@@ -3121,6 +3131,7 @@ void handleApiBootAnimInstall() {
       if (n <= 0) break;
       out.write(buf, n);
       total += n;
+      if (total > MAX_ANIM_BYTES) { tooBig = true; break; }
       if (remaining > 0) { remaining -= n; if (remaining == 0) break; }
       if (millis() - lastDraw > 120) {       // size may be unknown; bar wraps every 256 KB
         lastDraw = millis();
@@ -3135,6 +3146,14 @@ void handleApiBootAnimInstall() {
   }
   out.close();
   http.end();
+
+  if (tooBig) {
+    SD.remove(savePath.c_str());          // don't leave a giant partial file eating the card
+    sendApiError(413, "animation too large");
+    netMessage("Boot animation", "file too large");
+    delay(1200); screen1();
+    return;
+  }
 
   bootAnimName = slug;          // installed animation becomes the active one
   saveDeviceConfig();

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -105,6 +105,7 @@ bool uvLedEnabled = true;           // false = dry-run motion/display only
 bool wifiEnabled = true;
 bool webDashboardEnabled = true;
 bool bootUpdateCheckEnabled = true;
+String bootAnimName = "";      // "" = built-in splash; else a basename in /bootanim/
 bool wifiTemporarilyEnabled = false;
 bool webDashboardTemporarilyEnabled = false;
 bool mqttEnabled = false;           // Smart Home / MQTT integration scaffold
@@ -152,6 +153,7 @@ void loadDeviceConfig() {
   wifiEnabled = sysPrefs.getBool("wifiEnabled", true);
   webDashboardEnabled = sysPrefs.getBool("webDash", true);
   bootUpdateCheckEnabled = sysPrefs.getBool("bootUpdChk", true);
+  bootAnimName = sysPrefs.getString("bootAnimName", "");
   mqttEnabled = sysPrefs.getBool("mqttEnabled", false);
   mqttHost = sysPrefs.getString("mqttHost", "");
   mqttPort = sysPrefs.getUShort("mqttPort", 1883);
@@ -183,6 +185,7 @@ void saveDeviceConfig() {
   sysPrefs.putBool("wifiEnabled", wifiEnabled);
   sysPrefs.putBool("webDash", webDashboardEnabled);
   sysPrefs.putBool("bootUpdChk", bootUpdateCheckEnabled);
+  sysPrefs.putString("bootAnimName", bootAnimName);
   sysPrefs.putBool("mqttEnabled", mqttEnabled);
   sysPrefs.putString("mqttHost", mqttHost);
   sysPrefs.putUShort("mqttPort", mqttPort);
@@ -453,6 +456,9 @@ String buildConfigBackupJson() {
   out += webDashboardEnabled ? "true" : "false";
   out += ",\"bootUpdateCheck\":";
   out += bootUpdateCheckEnabled ? "true" : "false";
+  out += ",\"bootAnim\":\"";
+  out += backupEscape(bootAnimName);
+  out += "\"";
   out += ",\"mqttEnabled\":";
   out += mqttEnabled ? "true" : "false";
   out += ",\"mqttHost\":\"";
@@ -544,6 +550,7 @@ void applyConfigBackup(const String &j) {
   wifiEnabled = backupBool(j, "wifiEnabled", wifiEnabled);
   webDashboardEnabled = wifiEnabled && backupBool(j, "webDashboardEnabled", webDashboardEnabled);
   bootUpdateCheckEnabled = backupBool(j, "bootUpdateCheck", bootUpdateCheckEnabled);
+  bootAnimName = backupStr(j, "bootAnim", bootAnimName);
   mqttEnabled = wifiEnabled && backupBool(j, "mqttEnabled", mqttEnabled);
   mqttHost = backupStr(j, "mqttHost", mqttHost);
   mqttPort = backupClamp(backupNum(j, "mqttPort", mqttPort), 1, 65535);


### PR DESCRIPTION
## What this adds

Downloadable **boot animations** — a small on-device library of named animations you can pick from, manage on the printer and in the dashboard, and install straight from the community site.

**Format — `TMB1`:** a tiny binary the ESP32 blits with no decompression — 12-byte header (`"TMB1"` magic, `uint16` width/height/frameCount/fps) + raw RGB565 frames. At 160×80 that's 25.6 KB/frame.

### On the printer
- `screen0()` plays the selected animation from `/bootanim/<name>.tmb` (blitted with `draw16bitRGBBitmap`), falling back to the built-in "Tiny Maker" splash.
- **System → Advanced → "Boot animation"** cycles `Default → each installed animation`. Selection persists in NVS and is included in config backup/restore.

### Over the web
- `POST /api/boot-anim/install` — the printer **pulls** a `TMB1` file from a URL, verifies the magic before writing, stores it in `/bootanim`, and makes it active (CORS + `OPTIONS` so a cross-origin "Send to printer" button can call it — same pull model as the firmware self-update).
- `GET /api/boot-anim` + `POST /api/boot-anim/select` / `/delete`.
- A **Boot animation** card on the dashboard Settings view to pick/delete installed animations.
- The install-result screen is recoverable (returns to the menu on success/failure).

## ⚠️ This PR includes the main→0.14.0 sync

`experimental` is currently behind `main`. The feature depends on 0.14.0 (Advanced-menu numbering, the dashboard, config backup), so the branch is based on a merge of `main` into `experimental`, and this PR therefore also contains those sync commits. **If you land that sync into `experimental` first, this PR will reduce to just the boot-animation commit.** Happy to reshape however you prefer.

## Companion app

The community site that hosts/serves the animations is a separate **Laravel** app (kept out of this firmware repo per CONTRIBUTING). It mirrors the `GET /api/animations` + download contract the firmware pulls from.

## Checklist

- [x] CI green — both envs compile (`tinymaker` + `tinymaker-ota`)
- [x] Still compiles with `ENABLE_NETWORK 0` (SD library helpers + on-device playback are outside the network block; API/dashboard are network-guarded)
- [x] No new blocking work in mid-print network paths (install is gated on `printerBusy()`; downloads only run when idle)
- [ ] Screenshots — dashboard card + on-device menu (to add)

## User-visible behavior

New: a boot-animation library and selector (on-device + dashboard), and a "Send to printer" install path. Default boot behavior is unchanged unless the user selects a downloaded animation.

## Testing

Tested end-to-end on hardware: sent multiple animations from the community site → printer stored them in `/bootanim` → dashboard card + Advanced menu list and select them. Compile verified for both envs and the network-free build.
