### PR TITLE
0-21: idle screen saver (dim text drifts between 5 spots)

### DIFF
--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -781,16 +781,23 @@ void screen421Buttons(bool installActive){
  * drawn once when idling starts (handleUiTimeout latches uiBlanked), redrawn
  * as the normal UI on the next key/network wake.
  */
-void drawIdleScreen(){
+void drawIdleScreen(uint8_t pos){
+  // 0-21 screen saver: place the dim block at one of 5 spots (4 corners +
+  // centre) so nothing burns in. Block = "TinyMaker" (size 2, ~108x16) with the
+  // IP on a line below; the IP is left-aligned under the wordmark so it never
+  // runs off the edge (it is narrower than the wordmark).
+  const int bw = 108, bh = 26, W = 160, H = 80, m = 6;
+  int x = (pos == 1 || pos == 3) ? (W - bw - m) : (pos == 4) ? (W - bw) / 2 : m;
+  int y = (pos == 2 || pos == 3) ? (H - bh - m) : (pos == 4) ? (H - bh) / 2 : m;
   gfx2->fillScreen(BLACK);
   gfx2->setFont(NULL);
   gfx2->setTextSize(2);
   gfx2->setTextColor(0x4208);            // dim grey wordmark
-  gfx2->setCursor(10, 16);
+  gfx2->setCursor(x, y);
   gfx2->print("TinyMaker");
   gfx2->setTextSize(1);
   gfx2->setTextColor(0x2124);            // dimmer secondary line
-  gfx2->setCursor(10, 48);
+  gfx2->setCursor(x, y + 18);
   if (WiFi.status() == WL_CONNECTED) gfx2->print(WiFi.localIP());
   else gfx2->print("Idle");
   gfx2->setTextSize(1);

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -147,6 +147,8 @@ bool statsPingEnabled = true;       // anonymous install ping (MAC hash + versio
 uint8_t prevRegularExposure = 0;    // last replaced Regular exposure (0 = none) - dashboard Undo
 unsigned long lastUiActivityMs = 0;
 bool uiBlanked = false;
+uint8_t uiSaverPos = 0;               // 0-21 idle screen saver: which of the 5 spots
+unsigned long uiSaverLastMoveMs = 0;  // last time the idle text drifted
 
 void savePrintTime() {
   totalPrintSecs += (millis() - printStartMs) / 1000UL;
@@ -775,15 +777,31 @@ bool handleUiTimeout() {
     }
   }
 
-  if (uiTimeoutSecs == 0 || uiBlanked || printerBusy()) return false;
+  if (uiTimeoutSecs == 0 || printerBusy()) return false;
+
+  // Already idling: drift the dim text between 5 spots (4 corners + centre)
+  // every couple of seconds (0-21 screen saver) so nothing burns in.
+  if (uiBlanked) {
+#if ENABLE_NETWORK
+    if (millis() - uiSaverLastMoveMs >= 2000UL) {
+      uiSaverLastMoveMs = millis();
+      uiSaverPos = (uiSaverPos + 1) % 5;
+      drawIdleScreen(uiSaverPos);
+    }
+#endif
+    return false;
+  }
+
   if (!(screen == 1 || screen == 2 || screen == 3 || screen == 4)) return false;
   if (millis() - lastUiActivityMs < (unsigned long)uiTimeoutSecs * 1000UL) return false;
 
   // The backlight is hard-wired on, so displayOff() would leave a lit black
-  // panel. Draw a dim status instead (0-15): same power, but the printer looks
-  // alive and its IP stays visible. uiBlanked latches so it is drawn once.
+  // panel. Draw a dim status instead (0-15/0-21): same power, but the printer
+  // looks alive and its IP stays visible.
 #if ENABLE_NETWORK
-  drawIdleScreen();
+  uiSaverPos = 0;
+  uiSaverLastMoveMs = millis();
+  drawIdleScreen(uiSaverPos);
 #else
   gfx2->fillScreen(BLACK);
   ((Arduino_TFT *)gfx2)->displayOff(); // no network build: nothing useful to show


### PR DESCRIPTION
Follow-up to 0-15 dim idle: while the printer idles, the dim "TinyMaker" + IP block moves between 5 positions (4 corners + centre) every ~2 s so nothing burns in and it reads as alive. `drawIdleScreen(pos)` places the block per spot (IP left-aligned under the wordmark, never off the edge); `handleUiTimeout` advances the position on a timer while blanked. Non-network build keeps the old blank.

Builds clean (flash 69.1%); tested on the printer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)