### PR TITLE
security: allowlist boot-anim install URL, drop its CORS wildcard (M1)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -108,7 +108,7 @@ retries with `action`.
 |---|---|---|
 | `/api/telegram/test`, `/api/whatsapp/test`, `/api/discord/test` | POST | send a test notification with the saved credentials |
 | `/api/connect/test`, `/register`, `/recovery-code`, `/backup` (GET/POST), `/restore` | POST/GET | TinyMaker Connect pairing + settings backup |
-| `/api/boot-anim` (+ `/file`, `/select`, `/delete`, `/preview`, `/install`) | GET/POST | boot-animation management; `/install` allows CORS preflight for the web flasher |
+| `/api/boot-anim` (+ `/file`, `/select`, `/delete`, `/preview`, `/install`) | GET/POST | boot-animation management; `/install` pulls a `.tmb` only from allowlisted hosts (gh-pages library, configured Connect server) — other sources go onto the SD card by hand |
 
 ## Static
 

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -2369,10 +2369,11 @@ void drawWifiBadge() {
   gfx2->fillRect(154, 2, 2, 9, c);   // tall bar (ends 2 px from the edge)
 }
 
-// Boot-animation install: the printer pulls a TMB1 file from a community URL and
+// Boot-animation install: the printer pulls a TMB1 file from a trusted URL and
 // stores it in the /bootanim library, then makes it the active boot animation.
-// CORS header so the cross-origin "Send to printer" page can read our reply.
-//   POST /api/boot-anim/install   body: url=<http/https .tmb url>&name=<slug>
+// The URL is allowlisted to hosts we control (gh-pages default library and the
+// configured Connect server) — anything else goes onto the SD card by hand.
+//   POST /api/boot-anim/install   body: url=<allowlisted .tmb url>&name=<slug>
 String bootAnimMetadataPath(const String &name) {
   return String(BOOTANIM_DIR) + "/" + name + ".json";
 }
@@ -2441,8 +2442,6 @@ bool writeBootAnimMetadataFile(const String &slug) {
 }
 
 void handleApiBootAnimInstall() {
-  server.sendHeader("Access-Control-Allow-Origin", "*");
-
   if (rejectIfWebControlOff()) return;                       // 403 when web control off
   if (printerBusy())   { sendApiError(409, "printer busy"); return; }
   if (!sdCardReady())  { sendApiError(503, "sd card unavailable"); return; }
@@ -2452,6 +2451,14 @@ void handleApiBootAnimInstall() {
   url.trim();
   if (!(url.startsWith("http://") || url.startsWith("https://"))) {
     sendApiError(400, "missing or invalid url");
+    return;
+  }
+  // SSRF guard: only pull from hosts we control. Both are ours, so following
+  // redirects stays safe; other sources install by copying onto the SD card.
+  if (!(url.startsWith("https://slibbinas.github.io/") ||
+        (connectBaseUrl.length() > 0 &&
+         url.startsWith(connectNormalizeBaseUrl(connectBaseUrl) + "/")))) {
+    sendApiError(403, "url host not allowed");
     return;
   }
 
@@ -2890,12 +2897,6 @@ void network_setup() {
   server.on("/api/boot-anim/delete", HTTP_POST, handleApiBootAnimDelete);
   server.on("/api/boot-anim/preview", HTTP_POST, handleApiBootAnimPreview);
   server.on("/api/boot-anim/install", HTTP_POST, handleApiBootAnimInstall);
-  server.on("/api/boot-anim/install", HTTP_OPTIONS, []() {   // CORS preflight
-    server.sendHeader("Access-Control-Allow-Origin", "*");
-    server.sendHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-    server.sendHeader("Access-Control-Allow-Headers", "Content-Type");
-    server.send(204);
-  });
   server.on("/api/files/local", HTTP_POST, finishUpload, handleUploadData);
 
   // Plain endpoint for curl / UVtools testing:


### PR DESCRIPTION
Closes **M1** from the 0-12 security audit — the one MEDIUM on the HTTP surface we agreed to fix before 1.0.0.

**What changed in `/api/boot-anim/install`:**
- `url=` is now allowlisted: only the gh-pages default library (`https://slibbinas.github.io/`, same host as self-update) or the configured Connect base URL. Anything else → `403 url host not allowed`. Redirect following stays, both hosts are ours.
- `Access-Control-Allow-Origin: *` + the OPTIONS preflight removed — an HTTPS caller is blocked by mixed content before CORS matters (#12), and the agreed LNA path is opt-in headers behind a flag, not an always-on wildcard.

**Not affected:** dashboard's Default library installs (gh-pages ✓), Connect gallery installs (✓), manual SD copy of `.tmb` into `/bootanim` (still listed/selectable — the documented escape hatch).

api.md updated to match (it claimed the CORS preflight was for the web flasher; that path never worked over HTTPS).

Not yet flashed to a printer — needs a build + smoke test (install a default anim from the dashboard's library) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)