### PR TITLE
feat: feedback tickets + recently-handled list (0-7)

### DIFF
--- a/Firmware_Hosting/feedback-worker/src/index.js
+++ b/Firmware_Hosting/feedback-worker/src/index.js
@@ -8,10 +8,20 @@
 //   GET  /feedback/img?key=..&k=img:..  -> one stored photo
 //   POST /feedback/mark?key=..&k=fb:..  -> triage: {tag, handled, verdict}
 //   POST /feedback/del?key=..&k=fb:..   -> drop one note and its photos
+//   GET  /feedback/status?t=<token>     -> PUBLIC: the submitter's own note's
+//                                          status (ticket - 0-7)
+//   GET  /feedback/recent               -> PUBLIC: last 5 handled notes,
+//                                          number/tag/fw only (0-7)
 //
 // Triage lives on the record itself: the maintainer tags it (submitters
 // mis-file their own notes), ticks it handled, and writes the agreed verdict
 // so the decision stays glued to what prompted it.
+//
+// Verdict visibility rule (0-7, agreed 2026-07-22): notes carrying a ticket
+// token (everything submitted after this shipped) show their verdict to the
+// holder of the token - so write verdicts knowing the submitter reads them.
+// Older verdicts were written as private and are never exposed; the public
+// recent-fixed list carries no verdict text at all.
 //
 // Every record also carries {n, fw, tag, handled, ph} in its KV *metadata*.
 // KV list() hands metadata back for free, so the stats block, the filter
@@ -239,6 +249,10 @@ export default {
         });
         imgKeys.push(k);
       }
+      // 0-7 ticket: an unguessable token the submitter keeps. It buys one
+      // extra KV write per note (tok: -> fb: pointer) - accounted for in the
+      // daily-cap math, which already assumed ~3 writes plus photos.
+      const tok = crypto.randomUUID();
       const rec = {
         num,
         message: msg,
@@ -252,11 +266,61 @@ export default {
         src: fields.fw ? 'printer' : 'site',
         photos: imgKeys,
         at: stamp,
+        tok,
       };
       await env.FEEDBACK.put('fb:' + stamp + ':' + id, JSON.stringify(rec),
                              { metadata: metaOf(rec) });
-      return new Response(JSON.stringify({ ok: true, id: num, photos: imgKeys.length }), {
+      await env.FEEDBACK.put('tok:' + tok, 'fb:' + stamp + ':' + id);
+      return new Response(JSON.stringify({ ok: true, id: num, photos: imgKeys.length, token: tok }), {
         headers: { 'Content-Type': 'application/json', ...CORS },
+      });
+    }
+
+    // 0-7 PUBLIC ticket status: the token IS the authorisation - unguessable
+    // (uuid), and a wrong one answers 404 with no timing-relevant difference.
+    // Only status fields go back out - never the message or the contact (a
+    // leaked link should not leak what was written), and the verdict only for
+    // token-era notes (see the visibility rule up top).
+    if (path === '/feedback/status' && request.method === 'GET') {
+      const t = (url.searchParams.get('t') || '').trim();
+      // ACAO:* here is deliberate (unlike the key-gated routes): read-only
+      // public-by-token data, and the form's gh-pages fallback origin needs it.
+      const noStore = { 'Content-Type': 'application/json', 'Cache-Control': 'no-store',
+                        'Access-Control-Allow-Origin': '*' };
+      const miss = () => new Response('{"error":"unknown ticket"}', { status: 404, headers: noStore });
+      if (!/^[0-9a-f-]{36}$/.test(t)) return miss();
+      const fbKey = await env.FEEDBACK.get('tok:' + t);
+      const v = fbKey && await env.FEEDBACK.get(fbKey);
+      if (!v) return miss();
+      const rec = JSON.parse(v);
+      return new Response(JSON.stringify({
+        ok: true, num: rec.num, at: rec.at, fw: rec.fw || '',
+        tag: rec.tag || '', handled: !!rec.handled,
+        verdict: rec.tok ? (rec.verdict || '') : '', verdictAt: rec.tok ? (rec.verdictAt || '') : '',
+      }), { headers: noStore });
+    }
+
+    // 0-7 PUBLIC recently-handled list: metadata only (one KV list call, no
+    // record reads, no verdict text), capped at 5 and edge-cached so the form
+    // page can show it on every load without touching the read budget.
+    if (path === '/feedback/recent' && request.method === 'GET') {
+      const rows = [];
+      let cursor;
+      do {
+        const page = await env.FEEDBACK.list({ prefix: 'fb:', limit: 1000, cursor });
+        for (const k of page.keys) rows.push({ key: k.name, m: k.metadata || {} });
+        cursor = page.list_complete ? null : page.cursor;
+      } while (cursor);
+      rows.reverse();
+      const out = [];
+      for (const e of rows) {
+        if (!e.m.handled) continue;
+        out.push({ num: e.m.n || 0, tag: e.m.tag || '', fw: e.m.fw || '', at: e.key.slice(3, 13) });
+        if (out.length >= 5) break;
+      }
+      return new Response(JSON.stringify(out), {
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300',
+                   'Access-Control-Allow-Origin': '*' },
       });
     }
 
@@ -435,7 +499,7 @@ function inboxPage(notes, listKey, view) {
       ${(n.photoUrls || []).length ? `<div class="shots">${n.photoUrls.map((u) =>
         `<a href="${esc(u)}" target="_blank" rel="noopener"><img src="${esc(u)}" alt="attached photo" loading="lazy"></a>`).join('')}</div>` : ''}
       <div class="verdict${n.verdict ? '' : ' blank'}">
-        <label>Verdict — what we agreed${n.verdictAt ? ` <span class="vat">${when(n.verdictAt)}</span>` : ''}</label>
+        <label>Verdict — what we agreed${n.tok ? ' <span class="vat" title="This note carries a ticket: its submitter reads this verdict through their status link">· visible to its submitter</span>' : ''}${n.verdictAt ? ` <span class="vat">${when(n.verdictAt)}</span>` : ''}</label>
         <textarea rows="2" placeholder="e.g. Real bug, fixed in 0.15.1 · Duplicate of the resin estimate note · Backlog #31, after 1.0.0">${esc(n.verdict)}</textarea>
         <button class="save" disabled>Save</button>
       </div>

--- a/docs/feedback/index.html
+++ b/docs/feedback/index.html
@@ -56,6 +56,19 @@ button:disabled{opacity:.6;cursor:default}
 .case b{color:var(--accent);font-family:ui-monospace,Consolas,monospace;font-size:16px}
 #alt{display:none;font-size:13.5px}
 a{color:#84bcf8;text-decoration:none}a:hover{text-decoration:underline}
+/* 0-7: the submitter's own ticket status (opened via the saved ?t= link). */
+#ticket{display:none;border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:10px;padding:12px 14px;margin-bottom:18px}
+#ticket h2{font-size:1rem;margin:0 0 4px}
+#ticket .st{font-weight:600}
+#ticket .st.open{color:var(--accent)}
+#ticket .st.done{color:var(--ok)}
+#ticket .vd{white-space:pre-wrap;overflow-wrap:anywhere;font-size:14px;margin-top:6px;color:var(--text)}
+/* 0-7: the last handled notes - proof the box is read, not a black hole. */
+#recent{display:none;margin-top:22px;border-top:1px solid var(--line);padding-top:12px}
+#recent h2{font-size:.78rem;text-transform:uppercase;letter-spacing:.07em;color:var(--muted);margin:0 0 6px}
+#recent ul{list-style:none;margin:0;padding:0;font-size:13px;color:var(--muted)}
+#recent li{padding:2px 0}
+#recent b{color:var(--accent);font-family:ui-monospace,Consolas,monospace}
 </style>
 </head>
 <body>
@@ -64,6 +77,7 @@ a{color:#84bcf8;text-decoration:none}a:hover{text-decoration:underline}
     <svg viewBox="0 0 64 64" aria-hidden="true"><rect x="8" y="40" width="48" height="9" rx="3" fill="#e8720c"/><rect x="14" y="27" width="36" height="9" rx="3" fill="#e8720c" opacity=".75"/><rect x="20" y="14" width="24" height="9" rx="3" fill="#e8720c" opacity=".5"/><path d="M22 6 A14 14 0 0 1 42 6" fill="none" stroke="#4da3ff" stroke-width="5" stroke-linecap="round"/></svg>
     <span>TinyMakerWifi</span>
   </div>
+  <div id="ticket"></div>
   <form id="f">
     <h1>Tell us how it's going</h1>
     <p>What works, what doesn't, what's missing — anything helps. It goes straight to the people building the firmware. No account, ~30 seconds. <span id="fwLine" class="fw"></span></p>
@@ -85,12 +99,57 @@ a{color:#84bcf8;text-decoration:none}a:hover{text-decoration:underline}
     <p>Your note landed safely. It genuinely shapes what gets built next.</p>
     <p id="caseNo" class="case"></p>
   </div>
+  <div id="recent"></div>
 </div>
 <script>
 (function(){
   var q=new URLSearchParams(location.search);
   var fw=(q.get('fw')||'').slice(0,20),build=(q.get('build')||'').slice(0,20);
   if(fw)document.getElementById('fwLine').textContent='Firmware '+fw+(build?' ('+build+')':'')+' - attached automatically.';
+  // Same origin normally; absolute fallback keeps the page working if opened
+  // straight off gh-pages (same rule as the submit fetch below).
+  var API=location.hostname==='tinymakerwifi.com'?'':'https://tinymakerwifi.com';
+
+  // 0-7 ticket status: the saved ?t= link shows the submitter their own
+  // note's state. Built with textContent - the verdict is maintainer text,
+  // but nothing here should ever be interpreted as HTML.
+  var tok=(q.get('t')||'').trim();
+  if(/^[0-9a-f-]{36}$/.test(tok)){
+    fetch(API+'/feedback/status?t='+encodeURIComponent(tok))
+      .then(function(r){return r.ok?r.json():null;})
+      .then(function(s){
+        if(!s||!s.ok)return;
+        var box=document.getElementById('ticket');
+        var h=document.createElement('h2');h.textContent='Your note #'+s.num;
+        var st=document.createElement('div');st.className='st '+(s.handled?'done':'open');
+        st.textContent=s.handled?'✓ Handled':'Open - in the queue';
+        var meta=document.createElement('div');meta.style.cssText='font-size:12.5px;color:var(--muted)';
+        meta.textContent=(s.tag?s.tag+' · ':'')+(s.fw?'fw '+s.fw+' · ':'')+String(s.at||'').slice(0,10);
+        box.appendChild(h);box.appendChild(st);box.appendChild(meta);
+        if(s.verdict){var vd=document.createElement('div');vd.className='vd';vd.textContent=s.verdict;box.appendChild(vd);}
+        box.style.display='block';
+      }).catch(function(){});
+  }
+
+  // 0-7 recently handled: proof the box is read. Empty or failed fetch just
+  // leaves the section hidden - the form must never wait on it.
+  fetch(API+'/feedback/recent')
+    .then(function(r){return r.ok?r.json():null;})
+    .then(function(list){
+      if(!list||!list.length)return;
+      var box=document.getElementById('recent');
+      var h=document.createElement('h2');h.textContent='Recently handled';
+      var ul=document.createElement('ul');
+      list.forEach(function(it){
+        var li=document.createElement('li');
+        var b=document.createElement('b');b.textContent='#'+it.num;
+        li.appendChild(b);
+        li.appendChild(document.createTextNode(' · '+(it.tag||'note')+(it.fw?' · fw '+it.fw:'')+(it.at?' · '+it.at:'')));
+        ul.appendChild(li);
+      });
+      box.appendChild(h);box.appendChild(ul);
+      box.style.display='block';
+    }).catch(function(){});
 
   // Arrived from the test checklist's "Send report": it left the report in
   // sessionStorage (same origin) rather than the URL - a wall of text in the
@@ -172,8 +231,22 @@ a{color:#84bcf8;text-decoration:none}a:hover{text-decoration:underline}
       if(!r.ok)throw new Error('HTTP '+r.status);
       return r.json().catch(function(){return {};});
     }).then(function(d){
-      if(d&&d.id)document.getElementById('caseNo').innerHTML=
-        'Your reference: <b>#'+d.id+'</b><br>Quote it if you follow up — in the group, by mail, anywhere.';
+      if(d&&d.id){
+        var c=document.getElementById('caseNo');
+        c.innerHTML='Your reference: <b>#'+d.id+'</b><br>Quote it if you follow up — in the group, by mail, anywhere.';
+        // 0-7: the status link is the only copy of the token - the server
+        // never shows it again. d.id and d.token both come from our own
+        // worker, but build the link safely anyway.
+        if(d.token&&/^[0-9a-f-]{36}$/.test(d.token)){
+          var a=document.createElement('a');
+          a.href='https://tinymakerwifi.com/feedback/?t='+encodeURIComponent(d.token);
+          a.textContent='Check its status any time with this link';
+          var p=document.createElement('p');p.className='case';
+          p.appendChild(a);
+          p.appendChild(document.createTextNode(' — bookmark it; it also shows our verdict once the note is handled.'));
+          c.parentNode.insertBefore(p,c.nextSibling);
+        }
+      }
       document.getElementById('f').style.display='none';
       document.getElementById('done').style.display='block';
     }).catch(function(){


### PR DESCRIPTION
**0-7** — closes the exp-3 web-hygiene item. The feedback box stops being a black hole. Firmware untouched; worker + form only. (0-8 service-worker shell deferred to ideas, per the plan — risk over reward.)

**Worker (public, no key):**
- POST mints an unguessable ticket token (`tok:` → `fb:` pointer) and returns it.
- `GET /feedback/status?t=<token>` → that one note's status: number, tag, handled, and the **verdict for token-era notes only** (older verdicts were written as private and are never exposed — the agreed visibility rule). Wrong/replayed token → flat 404. Never returns the message or contact.
- `GET /feedback/recent` → last 5 **handled** notes, number/tag/fw only (metadata, one list call, no verdict text), edge-cached 5 min.
- Both carry `ACAO:*` (read-only, public-by-token); the key-gated maintainer routes are unchanged.
- Inbox verdict box now flags token-era notes "visible to its submitter".

**Form:**
- A saved `?t=` link shows the submitter their own status + verdict.
- The post-send screen offers the status link (the only copy of the token).
- A "Recently handled" list at the bottom. All inserts are `textContent` (verdict is maintainer text, never HTML).

**Verified** against a local `wrangler dev`: POST→token, status valid/bogus/garbage (200/404/404), mark handled → verdict in status + note in /recent, inbox visibility flag; browser render of the ticket box, recent list and ticket-link builder, no console errors.

**Deploy note:** this is a worker + gh-pages form change — ships via `wrangler deploy` + gh-pages, **not** a firmware flash. No printer smoke test needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)