### PR TITLE
feat: one sticky snackbar for pause/stop/resume waits, with countdown

### DIFF
--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -1673,9 +1673,19 @@ const renderPrintWait=()=>{
   // toast) wiped it from under us - that clobber-then-restore was the flicker.
   if(txt===printWaitCur&&e.textContent===txt)return;
   const firstShow=!printWaitCur;   // animate only when the wait first appears
-  e.textContent=txt; e.classList.remove('warn'); e.style.top='14px';
+  e.textContent=txt; e.classList.remove('warn');
   clearTimeout(msg._t); msg._until=0;        // sticky: never auto-clear while waiting
-  if(firstShow){e.style.animation='none';void e.offsetWidth;e.style.animation='';}
+  if(firstShow){
+    // Show it by the button that triggered it, not pinned to the window top -
+    // the app's convention (toasts appear where you acted). Position once, on
+    // first appearance, so the countdown updates don't make it jump; clamp to
+    // the viewport, and fall back to the last-click Y if the button is off it.
+    const bid=info.v.slice(0,3)==='Sto'?'stopButton':info.v.slice(0,3)==='Pau'?'pauseButton':'resumeButton';
+    const b=$(bid), r=(b&&!b.classList.contains('hidden'))?b.getBoundingClientRect():null;
+    const y=(r&&r.height)?r.bottom+8:(typeof msg._y==='number'?msg._y+28:14);
+    e.style.top=Math.min(Math.max(y,14),innerHeight-80)+'px';
+    e.style.animation='none';void e.offsetWidth;e.style.animation='';
+  }
   printWaitCur=txt;
 };
 let lastPollOkAt=0;

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -819,7 +819,7 @@ const applyStatus=s=>{
     if(!s.busy){localPrintStartedAt=0;lpsSynced=false;}
     if((pendingPrintCmd==='stop'&&s.stopping)||(pendingPrintCmd==='pause'&&(s.pausing||s.paused))||(pendingPrintCmd==='resume'&&s.resuming))pendingPrintCmd='';
     phaseRx=(s.busy&&s.phaseTotalMs>0)?{remainMs:Math.max(0,s.phaseTotalMs-s.phaseElapsedMs),at:Date.now()}:null;
-    renderStateValue(); setText('wifiValue',s.wifiText); setText('ipValue',s.ip); setText('lifetimeValue',s.lifetimePrintTime); setText('uvLedValue',s.uvLedTime||'-'); setText('sdValue',s.sdText);
+    renderStateValue(); renderPrintWait(); setText('wifiValue',s.wifiText); setText('ipValue',s.ip); setText('lifetimeValue',s.lifetimePrintTime); setText('uvLedValue',s.uvLedTime||'-'); setText('sdValue',s.sdText);
     // 0-30 reset-reason telemetry: surface a NEW mid-print death once (the
     // record persists on the printer, so remember what was already shown).
     if(s.lastCrash&&s.lastCrash.reason){const ck=s.lastCrash.reason+'@'+s.lastCrash.layer;
@@ -1539,12 +1539,14 @@ const retryPendingPrintCommand=async()=>{
   try{
     await api('/api/print/'+cmd,{method:'POST'},30000);
     pendingPrintCmd='';
-    msg((cmd==='stop'?'Stop':cmd==='pause'?'Pause':'Resume')+' accepted.');
+    // No "accepted" toast: the wait snackbar (renderPrintWait) now owns this
+    // feedback and keeps showing "Stopping ... ~Xs" until the printer resolves.
     refreshStatus();
   }catch(e){
+    // A genuine "nothing to do" answer clears the wait; a network hiccup leaves
+    // pendingPrintCmd set so the wait snackbar keeps showing "... requested".
     if(e.message.indexOf('not printing')>=0||e.message.indexOf('not paused')>=0){pendingPrintCmd='';msg(e.message,true);}
-    else msg((cmd==='stop'?'Stop':cmd==='pause'?'Pause':'Resume')+' requested. Waiting for the next safe network window...',true);
-  }finally{pendingPrintInFlight=false;applyPendingPrintUi();}
+  }finally{pendingPrintInFlight=false;applyPendingPrintUi();renderPrintWait();}
 };
 const startPrint=async(nameEnc,force)=>{const name=decodeURIComponent(nameEnc||enc(selectedModel));if(!name)return;clearNew(name);if(!force&&!await uiConfirm('Start this print?'))return;
   if(!force&&statusData&&statusData.askRefill){
@@ -1611,7 +1613,7 @@ const startPrint=async(nameEnc,force)=>{const name=decodeURIComponent(nameEnc||e
 // timeouts instead of flashing "Status unavailable" (user finding, 0.14.3).
 let deleteBusy=false;
 const deleteFile=async nameEnc=>{const name=decodeURIComponent(nameEnc);if(!await uiConfirm('Delete this SD item?',{danger:true}))return;deleteBusy=true;msg('Deleting '+name+' - large models take a while, the printer answers when done...',false,true);try{await api('/api/files/delete?name='+enc(name),{method:'POST'},180000);deleteBusy=false;msg('Deleted '+name+'.');if(localStorage.getItem('dashPreviewModel')===name)localStorage.removeItem('dashPreviewModel');if(dashPreviewName===name)dashPreviewPlaceholder();loadFiles();refreshStatus();}catch(e){deleteBusy=false;msg(e.message,true);}};
-const printCommand=async(cmd,confirmText)=>{if(confirmText&&!await uiConfirm(confirmText,{danger:cmd==='stop'}))return;pendingPrintCmd=cmd;applyPendingPrintUi();msg((cmd==='stop'?'Stop':cmd==='pause'?'Pause':'Resume')+' requested. Waiting for printer connection...',true);retryPendingPrintCommand();};
+const printCommand=async(cmd,confirmText)=>{if(confirmText&&!await uiConfirm(confirmText,{danger:cmd==='stop'}))return;pendingPrintCmd=cmd;applyPendingPrintUi();renderPrintWait();retryPendingPrintCommand();};
 const fmtDur=ms=>{const s=Math.floor(ms/1000),h=Math.floor(s/3600),m=Math.floor(s%3600/60);return h>0?h+'h '+m+'m':m+'m '+(s%60)+'s';};
 // "Curing · 9s" next to the state - the phase's remaining time, ticked locally
 // between polls: mid-print the printer answers polls only in short windows
@@ -1627,6 +1629,52 @@ const renderStateValue=()=>{
   }
   setText('stateValue',t);
 };
+// A pause/stop/resume takes real time - the printer finishes the current layer
+// (and, for a stop, lifts the plate) before it acts. That used to show only as
+// a subtle button label ("Stopping...") that was easy to miss, while the wait
+// seconds sat separately on the State line. This drives one sticky snackbar for
+// the whole wait - what is happening + the live phase countdown - matching how
+// other long operations announce themselves, and clears itself when the printer
+// resolves. The button label stays as a secondary cue. Called after every
+// status apply and every local tick, so the countdown updates smoothly.
+let printWaitCur='';
+const printWaitInfo=()=>{
+  const s=statusData; if(!s)return null;
+  if(s.busy&&s.stopping)  return {v:'Stopping', tail:' — finishing the current layer, then the plate lifts', count:true};
+  if(s.busy&&s.pausing)   return {v:'Pausing',  tail:' — the print pauses after this layer', count:true};
+  if(s.busy&&s.resuming)  return {v:'Resuming', tail:' — the print is starting again', count:true};
+  // Requested but the printer has not confirmed yet (it answers between layers).
+  if(pendingPrintCmd==='stop')   return {v:'Stop requested',   tail:' — waiting for the printer (it answers between layers)', count:false};
+  if(pendingPrintCmd==='pause')  return {v:'Pause requested',  tail:' — waiting for the printer (it answers between layers)', count:false};
+  if(pendingPrintCmd==='resume') return {v:'Resume requested', tail:' — waiting for the printer (it answers between layers)', count:false};
+  return null;
+};
+const renderPrintWait=()=>{
+  const info=printWaitInfo();
+  if(!info){
+    if(printWaitCur){
+      const wasStop=printWaitCur.indexOf('Stop')===0, wasPause=printWaitCur.indexOf('Paus')===0;
+      const e=$('statusMsg'); if(e.textContent===printWaitCur)e.textContent='';
+      printWaitCur='';
+      // one-shot closure, transient (the wait is over)
+      if(wasStop&&statusData&&!statusData.busy)msg('Print stopped.');
+      else if(wasPause&&statusData&&statusData.paused)msg('Print paused.');
+    }
+    return;
+  }
+  let secs='';
+  if(info.count&&statusData&&statusData.busy&&phaseRx){
+    const rem=phaseRx.remainMs-(Date.now()-phaseRx.at);
+    if(rem>-1500)secs=' · ~'+Math.max(0,Math.ceil(rem/1000))+'s';
+  }
+  const txt=info.v+info.tail+secs;
+  if(txt===printWaitCur)return;              // nothing changed this tick
+  const e=$('statusMsg'), firstShow=!printWaitCur;   // animate only on first appearance
+  e.textContent=txt; e.classList.remove('warn'); e.style.top='14px';
+  clearTimeout(msg._t); msg._until=0;        // sticky: never auto-clear while waiting
+  if(firstShow){e.style.animation='none';void e.offsetWidth;e.style.animation='';}
+  printWaitCur=txt;
+};
 let lastPollOkAt=0;
 const tickLocalStatus=()=>{
   const busyNow=statusData&&statusData.busy;
@@ -1634,6 +1682,7 @@ const tickLocalStatus=()=>{
     setText('runValue',fmtDur(Date.now()-localPrintStartedAt));
     renderStateValue();
   }
+  renderPrintWait();   // tick the wait snackbar's countdown between polls
   // Liveness: only meaningful mid-print, where answers arrive in windows.
   const stale=busyNow&&Date.now()-lastPollOkAt>4000;
   show('syncDot',!!busyNow);

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -953,12 +953,12 @@ const refreshStatus=async()=>{
     statusFailCount=0;
     applyStatus(s);
     if(typeof renderGs==='function')renderGs(); // auto-tick "first print"
-    if(!pendingPrintCmd&&!deleteBusy&&(!msg._until||Date.now()>=msg._until))msg('',false);
+    if(!pendingPrintCmd&&!deleteBusy&&!printWaitCur&&(!msg._until||Date.now()>=msg._until))msg('',false);
   }catch(e){
     statusFailCount++;
     if(updLock)updSawDown=true;
     if(deleteBusy)msg('Deleting - the printer is busy removing files...',false,true);
-    else if(statusData&&statusData.busy)msg('Syncing with printer at the next safe network window...',true);
+    else if(statusData&&statusData.busy&&!printWaitCur&&statusFailCount>=2)msg('Syncing with printer at the next safe network window...',true);
     // A single missed poll is routine while the printer does SD-heavy work
     // (scans, slice streaming) - only speak up when it keeps failing. An
     // out-of-band import (PrusaSlicer upload) blocks the whole web server
@@ -1668,8 +1668,11 @@ const renderPrintWait=()=>{
     if(rem>-1500)secs=' · ~'+Math.max(0,Math.ceil(rem/1000))+'s';
   }
   const txt=info.v+info.tail+secs;
-  if(txt===printWaitCur)return;              // nothing changed this tick
-  const e=$('statusMsg'), firstShow=!printWaitCur;   // animate only on first appearance
+  const e=$('statusMsg');
+  // Re-assert if the text changed OR something (the poll loop's clear, another
+  // toast) wiped it from under us - that clobber-then-restore was the flicker.
+  if(txt===printWaitCur&&e.textContent===txt)return;
+  const firstShow=!printWaitCur;   // animate only when the wait first appears
   e.textContent=txt; e.classList.remove('warn'); e.style.top='14px';
   clearTimeout(msg._t); msg._until=0;        // sticky: never auto-clear while waiting
   if(firstShow){e.style.animation='none';void e.offsetWidth;e.style.animation='';}

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -1613,7 +1613,15 @@ const startPrint=async(nameEnc,force)=>{const name=decodeURIComponent(nameEnc||e
 // timeouts instead of flashing "Status unavailable" (user finding, 0.14.3).
 let deleteBusy=false;
 const deleteFile=async nameEnc=>{const name=decodeURIComponent(nameEnc);if(!await uiConfirm('Delete this SD item?',{danger:true}))return;deleteBusy=true;msg('Deleting '+name+' - large models take a while, the printer answers when done...',false,true);try{await api('/api/files/delete?name='+enc(name),{method:'POST'},180000);deleteBusy=false;msg('Deleted '+name+'.');if(localStorage.getItem('dashPreviewModel')===name)localStorage.removeItem('dashPreviewModel');if(dashPreviewName===name)dashPreviewPlaceholder();loadFiles();refreshStatus();}catch(e){deleteBusy=false;msg(e.message,true);}};
-const printCommand=async(cmd,confirmText)=>{if(confirmText&&!await uiConfirm(confirmText,{danger:cmd==='stop'}))return;pendingPrintCmd=cmd;applyPendingPrintUi();renderPrintWait();retryPendingPrintCommand();};
+const printCommand=async(cmd,confirmText)=>{
+  if(confirmText&&!await uiConfirm(confirmText,{danger:cmd==='stop'}))return;
+  pendingPrintCmd=cmd;applyPendingPrintUi();
+  // On a phone the controls sit below the fold, so the wait snackbar (which
+  // anchors to the pressed button) would pin to the top. Bring the controls
+  // into view first - instantly, so the snackbar's position reads the settled
+  // rect - and only when they are actually out of sight (desktop shows them).
+  const pc=$('printControls'); if(pc){const r=pc.getBoundingClientRect(); if(r.top<0||r.bottom>innerHeight)pc.scrollIntoView({block:'center'});}
+  renderPrintWait();retryPendingPrintCommand();};
 const fmtDur=ms=>{const s=Math.floor(ms/1000),h=Math.floor(s/3600),m=Math.floor(s%3600/60);return h>0?h+'h '+m+'m':m+'m '+(s%60)+'s';};
 // "Curing · 9s" next to the state - the phase's remaining time, ticked locally
 // between polls: mid-print the printer answers polls only in short windows


### PR DESCRIPTION
Stopping a print takes real time — the printer finishes the current layer and lifts the plate first — but the only feedback was a subtle **Stopping...** button label (easy to miss), while the wait seconds sat separately on the State line (field report from V). Pause/resume had the same split.

**Now** all three drive **one sticky snackbar** for the whole wait:

> Stopping — finishing the current layer, then the plate lifts · ~18s

with the live phase countdown ticked between polls. It clears itself when the printer resolves and drops a one-shot **Print stopped.** / **Print paused.** The button label stays as a secondary cue. Before the printer confirms (it answers between layers) it reads *"… requested — waiting for the printer"*. Replaces the old transient toasts (*Stop accepted*, *Waiting for connection*) that flashed and vanished before the real wait began.

**Verified in-browser** across stopping / pausing / pending / resolve: countdown ticks 23→18 s, closure toast fires, clears cleanly; no console errors; compile OK.

**To check on the printer (the "B" caveat):** whether firmware reports `phaseTotalMs` during the *Canceling* phase — if it does, `~Xs` shows during the stop; if not, the snackbar simply omits the number (still correct). Everything else works regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)