### PR TITLE
fix: show 'Testing - Curing' in dry run, not a bare 'Testing'

### DIFF
--- a/src/Network.ino
+++ b/src/Network.ino
@@ -699,7 +699,7 @@ String printerStateText() {
     String prefix = uvLedEnabled ? "" : "Testing - ";
     switch (current_state) {
       case 0: return prefix + "Homing";
-      case 1: return uvLedEnabled ? "Curing" : "Testing";
+      case 1: return prefix + "Curing";   // dry run: "Testing - Curing", like the other phases (was a bare "Testing")
       case 2: return prefix + "Lifting";
       case 3: return prefix + "Dropping";
       case 4: return prefix + "Canceling";


### PR DESCRIPTION
In dry run the State field reads `Testing - Homing`, `Testing - Lifting`, `Testing - Dropping` — but the curing phase special-cased to a bare **Testing**, so it looked like curing was skipped (field report from V).

The exposure phase still runs in dry run (the timing, just no UV), so it now reads `Testing - Curing` like every other phase; the `Testing -` prefix already signals it is not a real cure.

One-line change in `printerStateText()`; compile OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)