### PR TITLE
docs: GitHub issue templates (0-14)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Something on the printer or dashboard doesn't work the way it should
+title: ""
+labels: bug
+assignees: ""
+---
+
+**Firmware version + build**
+<!-- Dashboard header or Settings → About, e.g. 0.15.8 (28da502).
+     Not sure which channel you're on? The Update tab shows it. -->
+
+**What happened**
+<!-- What you did, what you expected, what you got instead. -->
+
+**Steps to reproduce**
+1.
+2.
+3.
+
+**Where does it show up?**
+<!-- Printer LCD / browser dashboard (phone or PC?) / PrusaSlicer upload /
+     Telegram-MQTT integration... -->
+
+**Photos / screenshots**
+<!-- A photo of the LCD or a dashboard screenshot says more than a
+     paragraph. For print-quality issues, a photo of the print helps. -->
+
+**Anything unusual around it?**
+<!-- Weak WiFi, two dashboards open at once, a print running, SD card
+     nearly full, power blip... whatever might be related. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Quick feedback (no GitHub account needed)
+    url: https://tinymakerwifi.com/feedback/
+    about: "The 30-second form: what works, what doesn't. You get a reference number and a status link - no account, photos welcome."
+  - name: TinyMaker community (Facebook group)
+    url: https://www.facebook.com/groups/1486879621729571
+    about: Questions, show-and-tell and community chat live here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request / big-PR heads-up
+about: Suggest an improvement, or check in before starting an ambitious PR
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**What would you like?**
+<!-- One or two sentences. -->
+
+**Why / what problem does it solve?**
+<!-- The story behind it beats the feature itself - "when X happens I
+     always have to Y" tells us more than a solution sketch. -->
+
+**Where would it live?**
+<!-- Printer screen / dashboard / slicer flow / integrations - if you
+     have an opinion. -->
+
+**Workaround today?**
+<!-- How do you cope without it right now, if at all? -->
+
+**Planning to build it yourself?**
+<!-- Great! Say so and sketch the approach - a quick "sound OK?" here
+     saves rework (see CONTRIBUTING.md: big work targets the
+     `experimental` branch). -->


### PR DESCRIPTION
Completes 0-14: CONTRIBUTING.md was already on main, this adds the issue-template pair + contact links (feedback form for non-devs, FB group).

**For V to review** - wording only, no code. Bug template asks for version+build and photos; feature template nudges big work toward `experimental` per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)