### PR TITLE
Add model-selection rules, audit rhythm, and firmware-auditor subagent

### DIFF
--- a/.claude/agents/firmware-auditor.md
+++ b/.claude/agents/firmware-auditor.md
@@ -1,0 +1,42 @@
+---
+name: firmware-auditor
+description: TinyMaker ESP32 firmware auditas. Naudok PROAKTYVIAI po kiekvienų
+  2-3 užbaigtų feature'ų arba prieš commit'ą. Analizuoja git diff.
+model: opus
+tools: Read, Grep, Glob, Bash
+---
+
+Audituoji TinyMaker MSLA spausdintuvo firmware (ESP32-WROOM-32E-N4, be PSRAM,
+~320 KB SRAM, Arduino, VS Code + PlatformIO).
+
+Analizuok TIK `git diff` — ne visą repo. Jei diff tuščias, taip ir pasakyk.
+
+Tikrinimo sąrašas (pagal realius šio projekto apribojimus):
+
+1. **Bendra SPI magistralė.** SD (CS 25) ir abu ekranai (CS 5, CS 4, bendras
+   DC 27) ant tos pačios VSPI. SdFat 1.1.2 nėra thread-safe. Ar naujas kodas
+   neliečia SD ar ekranų spausdinimo metu? Tinklo įkėlimai leidžiami TIK kai
+   spausdintuvas idle.
+2. **Heap'as.** Nėra PSRAM; WiFi stack'as suvalgo ~50-70 KB. Ar buferiai keli
+   KB? Ar naudojamas streaming'as vietoj pilno failo į RAM? Ar nėra
+   fragmentaciją keliančių alokacijų cikle?
+3. **Blokuojantis spausdinimo ciklas.** Visas spausdinimas — `loop()` viduje,
+   `case 111`. Ar pakeitimas nesuardė šios struktūros? Ar mygtukų apklausa
+   kas 500 ms išliko?
+4. **Bibliotekų versijos.** Arduino_GFX 1.2.0, SdFat 1.1.2, PNGdec 1.0.1,
+   AccelStepper 1.64. Ar nenaudojamas naujesnių versijų API (ypač Arduino_GFX
+   ir SdFat v2)?
+5. **Saugumas.** Ar UV LED garantuotai išjungtas VISAIS išėjimo keliais
+   (cancel, pause, error)? Ar iškviestas `disableOutputs()`, kad ULN2003
+   nekaistų?
+6. **Nustatymų saugojimas.** EEPROM (adresai 1-10) — po 1 baitą, sena sritis.
+   Nauji nustatymai turi eiti į Preferences/NVS.
+7. **GPIO.** Ar naujas pinas tikrai laisvas? Laisvų labai mažai.
+8. **CRLF.** Ar diff'e neatsirado eilučių galūnių pakeitimų?
+
+Grąžink trumpą sąrašą pagal svarbą: kritiška / verta pataisyti / smulkmena.
+Be pagyrimų ir be santraukų to, kas gerai. Jei nieko neradai — viena eilutė,
+kad švaru.
+
+Atsakymą formuluok taip, kad jį būtų patogu skaityti telefone: trumpos
+eilutės, be didelių kodo blokų — cituok tik problemines vietas.

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,11 @@ src/dashboard_html_gz.h
 # Local, private Claude skills (kept out of the public repo; backup: secret gist)
 .claude/skills/
 
-# Local Claude Code config (machine-specific)
-.claude/
+# Local Claude Code config (machine-specific), except shared subagents
+# (.claude/agents/ is committed so it travels with the repo into
+#  Claude Code on the web / Remote Control sessions)
+.claude/*
+!.claude/agents/
 
 Firmware_Hosting/feedback-worker/.wrangler/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,33 @@ Build-time switches (top of `TinyMaker.ino`):
 
 - `origin` → `slibbinas/TinyMakerWiFi` (this fork, active development)
 - `upstream` → `TinyMaker3D/TinyMaker-Open-Source-3D-Printer` (original project)
+
+## Modelio parinkimas
+
+Prieš pradėdamas užduotį, ją įvertink:
+
+- Platus refaktoringas, architektūros sprendimas, sunkus bug'as, auditas
+  → SUSTOK ir pasiūlyk `/model opus` (arba `/model opusplan`). Nepradėk vykdyti.
+- Mechaninis darbas (pervadinimai, log eilutės, boilerplate, regex)
+  → pasiūlyk `/model haiku`.
+- Kitais atvejais dirbk su dabartiniu modeliu, nieko neklausk.
+
+Pasiūlymas — viena eilutė su priežastimi. Nesiūlyk to paties du kartus
+toje pačioje sesijoje; jei vartotojas atmetė, daugiau nebeprimink.
+
+## Audito ritmas
+
+Po kiekvienų 2–3 užbaigtų feature'ų pasiūlyk paleisti `firmware-auditor`
+subagentą ant `git diff`. Nelauk darbo pabaigos — architektūrinę klaidą
+pigiau pagauti, kol ji dar neįaugusi į kelis feature'us.
+
+## Debesų sesijos (Claude Code on the web)
+
+Debesų sesijoje firmware kodas NĖRA sukompiliuotas PlatformIO ir NĖRA
+išbandytas ant geležies (flash'inimui reikia USB kabelio prie PC). Todėl:
+
+- Niekada nesiūlyk merge'inti firmware pakeitimų iš debesų sesijos.
+- Palik PR juodraštį (draft) ir aiškiai pažymėk, kad reikia kompiliacijos
+  PlatformIO ir testo ant spausdintuvo.
+- Debesų sesijoje pirmenybę teik ne kodavimui, o analizei, planavimui,
+  auditui, dokumentacijai ir projekto valdymo darbams.


### PR DESCRIPTION
Įdiegia „hook-free" darbo-eigos variantą iš `claudemodelworkflow.md` pasiūlymo (po peržiūros ir techninių pataisymų).

## Kas pridėta

**`CLAUDE.md`** — trys skyriai:
- **Modelio parinkimas** — opus/opusplan sunkiems darbams, haiku mechaniniams; su „nesiūlyk du kartus per sesiją" taisykle.
- **Audito ritmas** — po 2–3 feature'ų siūlyti `firmware-auditor`.
- **Debesų sesijos** — jokio firmware merge iš web, tik draft PR, pirmenybė analizei/dokumentacijai.

**`.claude/agents/firmware-auditor.md`** — Opus subagentas, kuris audituoja **tik `git diff`** pagal realius projekto apribojimus: bendra SPI magistralė, be PSRAM, blokuojantis print loop, prisegtos lib versijos, UV LED sauga, EEPROM/NVS, GPIO, CRLF. Atsakymas formuluojamas telefonui patogiu formatu.

**`.gitignore`** — išimtis tik `.claude/agents/`, kad bendrinamas subagentas keliautų su repo į web / Remote Control sesijas. `.claude/skills/` ir kita machine-specific config lieka privatu.

## Kodėl „hook-free" (Variant B)

Originalus pasiūlymas turėjo `UserPromptSubmit` hook'ą modelio pasiūlymams. Atsisakyta, nes:
- `additionalContext` **neveikia VS Code plėtinyje** (žinomas bug'as, GitHub #49063) — o tai pagrindinė darbo aplinka.
- Hook'as neturi atminties → dubliuotų CLAUDE.md ir siūlytų kaskart.

Tos pačios taisyklės CLAUDE.md faile veikia vienodai terminale, VS Code plėtinyje, Remote Control ir Claude Code on the web.

## Pastaba

Šie pakeitimai — ne firmware kodas (tik konfigūracija ir instrukcijos), tad kompiliacijos PlatformIO ar testo ant spausdintuvo nereikia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XZTq7yBae5NZqFivw7GSS)_