### PR TITLE
CLAUDE.md: verify code claims from the source, not memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,13 @@ Build-time switches (top of `TinyMaker.ino`):
 - `origin` → `slibbinas/TinyMakerWiFi` (this fork, active development)
 - `upstream` → `TinyMaker3D/TinyMaker-Open-Source-3D-Printer` (original project)
 
+## Tikslinimas iš kodo
+
+Prieš teigdamas ką nors apie kodą (eilutės numerį, funkcijos elgesį,
+kintamojo reikšmę, API, elgseną prie kraštinių sąlygų), patikrink tai
+realiame faile — Read/Grep — o ne iš atminties. Tai galioja VISADA ir
+visose sesijose, ne tik čia. Jei netikrinai — pasakyk, kad tai spėjimas.
+
 ## Modelio parinkimas
 
 Prieš pradėdamas užduotį, ją įvertink:


### PR DESCRIPTION
Prideda nuolatinę taisyklę į `CLAUDE.md`, galiojančią **visose sesijose**:

Prieš teigdamas ką nors apie kodą (eilutės numerį, funkcijos elgesį, kintamojo reikšmę, API, elgseną prie kraštinių sąlygų) — patikrinti realiame faile (Read/Grep), o ne remtis atmintimi. Jei netikrinta — aiškiai pasakyti, kad tai spėjimas.

Ne firmware kodas — tik projekto instrukcija, kompiliacijos/testo ant geležies nereikia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XZTq7yBae5NZqFivw7GSS)_