### PR TITLE
CLAUDE.md: plan page is a PC-session job, cloud captures issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,7 @@ išbandytas ant geležies (flash'inimui reikia USB kabelio prie PC). Todėl:
   PlatformIO ir testo ant spausdintuvo.
 - Debesų sesijoje pirmenybę teik ne kodavimui, o analizei, planavimui,
   auditui, dokumentacijai ir projekto valdymo darbams.
+- Plano puslapis (`tinymakerwifi.com/plan`) pildomas iš PC sesijos, ne iš
+  debesų — debesų aplinkos tinklo politika to host'o nepasiekia. Debesų
+  sesijoje idėjas fiksuok kaip GitHub issue'us (`[versija]` antraštėje);
+  PC sesija juos perkelia į planą.


### PR DESCRIPTION
Prideda eilutę į `CLAUDE.md` „Debesų sesijos" skyrių:

Plano puslapis (`tinymakerwifi.com/plan`) pildomas **iš PC sesijos**, ne iš debesų — debesų aplinkos tinklo politika to host'o nepasiekia (patikrinta: proxy grąžina 403 CONNECT). Debesų sesijoje idėjos fiksuojamos kaip GitHub issue'ai su `[versija]` antraštėje; PC sesija jas perkelia į planą.

Tikslas — ateities debesų sesijos negaišta bandydamos pasiekti planą ir iškart žino pasidalijimą.

Ne firmware kodas — tik projekto instrukcija.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XZTq7yBae5NZqFivw7GSS)_