### PR TITLE
docs: CLAUDE.md doc-map + feedback-worker.md panel routes + api.md version stamp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,27 @@ Build-time switches (top of `TinyMaker.ino`):
 #define ENABLE_SERIAL_DEBUG  1   // 0 = no serial output
 ```
 
+## Dokumentų žemėlapis
+
+Kai dirbi su konkrečia sritimi, pirma skaityk atitinkamą dokumentą (nekartok
+to, kas jau surašyta — ten pilnas kontekstas):
+
+| Kai dirbi su… | Skaityk |
+|---|---|
+| LAN API / HTTP endpoint'ais (`Network.ino`) | [docs/api.md](docs/api.md) |
+| PR — kur merge'inti, contribution taisyklės | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Cloudflare worker'iais / hosting'u / `/plan` `/team` `/tests` panel'ais | [Firmware_Hosting/](Firmware_Hosting/) + [feedback-worker.md](Firmware_Hosting/feedback-worker.md) |
+| Versijų kopėčiomis / kas kur išleista | [ROADMAP.md](ROADMAP.md) |
+| Release istorija | [CHANGELOG.md](CHANGELOG.md) |
+
+**PR šakos** (pilnos taisyklės — [CONTRIBUTING.md](CONTRIBUTING.md)): maža pataisa
+ar mažas self-contained feature → PR į `main`; didelis feature, WIP, daug failų →
+PR į `experimental`. `main` apsaugotas — CI (abu PlatformIO env) turi būti žalias.
+
+**Skill'ai:** firmware / spausdintuvo darbui, jei prieinamas, naudok
+`tinymaker-firmware` skill'ą. Jis globalus/plugin (ne repo viduje), tad švarioje
+debesų sesijoje ar kito žmogaus checkout'e gali jo nebūti — todėl „jei prieinamas".
+
 ## Remotes
 
 - `origin` → `slibbinas/TinyMakerWiFi` (this fork, active development)

--- a/Firmware_Hosting/feedback-worker.md
+++ b/Firmware_Hosting/feedback-worker.md
@@ -11,6 +11,33 @@ POST'ina į **atskirą** worker'į:
 - Įdiegta 2026-07-15 (versija a72a1317). `tinymaker-stats` worker'is NELIESTAS —
   feedback gyvena atskirai, kad stats/ping niekada nenukentėtų nuo formos.
 
+## Puslapiai ir KV panel'ai (tas pats worker'is servina daugiau nei feedback)
+
+Tas pats `tinymaker-feedback` worker'is servina ir statiškus puslapius iš KV
+raktų (`panel:*`). HTML įkeliamas iš PC su `wrangler`, NE iš repo.
+
+| Route | KV raktas | Prieiga | Įkėlimas |
+|---|---|---|---|
+| `/tests` | `panel:tests` | viešas | `wrangler kv key put panel:tests --path <failas.html>` |
+| `/plan` | `panel:plan` | secret **`LIST_KEY`** per `?key=`; blogas → **404** (nematomas) | `wrangler kv key put panel:plan --path planas.html` |
+| `/team` | `panel:team` | KV raktas **`key:team`** per `?key=` (NE LIST_KEY); blogas → **404** | `wrangler kv key put panel:team --path <failas.html>` |
+
+Proxy į gh-pages (be KV): `/demo`, `/manual`, `/roadmap`.
+
+**Gating pastaba:** `LIST_KEY` = Worker secret (`wrangler secret put LIST_KEY`);
+`key:team` = KV raktas (vienintelis toks — `wrangler kv key put key:team <secret>`).
+Blogas/nesamas raktas šiuose route'uose grąžina 404 (nematomą), ne 403.
+
+**Maintainer feedback route'ai** (visi po `LIST_KEY`): `/feedback/inbox`,
+`/feedback/csv`, `/feedback/list`, `/feedback/img`, `POST /feedback/mark`,
+`POST /feedback/del`. Vieši: `/feedback/status?t=<token>`, `/feedback/recent`.
+
+**Scope:** tas pats worker'is hostina ir atskirą **eInkWeather** projektą
+(`/orai` ← `panel:orai`, `/oi/<code>` ← `oi:<code>` PNG'ai) — ne TinyMaker, čia
+nedokumentuojama.
+
+Pilnas route'ų/KV šaltinis: `feedback-worker/src/index.js`.
+
 ## Skaitymas
 
 - CF dashboard → Storage & databases → Workers KV → `tinymaker-feedback`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,8 @@
 # TinyMakerWiFi LAN API (DRAFT v0 — 0-11)
 
 > Status: **draft for review** — generated from the endpoint registrations in
-> `src/Network.ino` (firmware 0.15.8, experimental branch). Promised in
+> `src/Network.ino`; the contract rides `FIRMWARE_VERSION` (see Versioning policy
+> below), so this doc is not pinned to a single release. Promised in
 > [Issue #12](https://github.com/slibbinas/TinyMakerWifi/issues/12) as the
 > versioned contract the Connect offload spec builds on.
 


### PR DESCRIPTION
Docs optimizacija, kad Claude sesijos patikimai rastų teisingą dokumentą teisingu metu. Tracking: #52.

## Keitimai (3 atskiri commit'ai, docs-only)

**1. `CLAUDE.md` — „Dokumentų žemėlapis" + workflow gairės**
- Lentelė „užduotis → failas": `docs/api.md`, `CONTRIBUTING.md`, `Firmware_Hosting/` + `feedback-worker.md`, `ROADMAP.md`, `CHANGELOG.md`.
- `main` vs `experimental` PR-šakos taisyklė (iš CONTRIBUTING).
- Soft pointer į globalų `tinymaker-firmware` skill'ą („jei prieinamas").

**2. `Firmware_Hosting/feedback-worker.md` — panel route'ai (doc-debt)**
- Route → KV raktas → prieiga → `wrangler kv key put` lentelė: `/tests` (`panel:tests`), `/plan` (`panel:plan`, `LIST_KEY`), `/team` (`panel:team`, `key:team`).
- Maintainer feedback route'ai; gh-pages proxy; gating (404 vs 403) pastaba.
- eInkWeather (`/orai`, `/oi`) — pažymėta out-of-scope.

**3. `docs/api.md` — versijos žyma**
- Nuimta dreifuojanti „firmware 0.15.8"; nukreipta į `FIRMWARE_VERSION`.

## Sauga

Docs-only — jokio firmware, jokio flash, kompiliacijos nereikia. Atskiri commit'ai per failą (bet kurį galima `git revert` atskirai). Pagal `CONTRIBUTING.md` docs = „small fix" → `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XZTq7yBae5NZqFivw7GSS)_