### PR TITLE
SEO + performance + LLM optimization for tinymakerwifi.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,14 @@ rekomenduojamo varianto ir vienos eilutės „kodėl" — trumpi pros/cons.
 Ne neutralus sąrašas, o aiški rekomendacija pirmiausia. Galioja visose
 sesijose.
 
+## Paprasta kalba
+
+Viską — pasiūlymus, paaiškinimus, techninius sprendimus — dėstyk PAPRASTA,
+ne technine kalba, kad vartotojui būtų lengva iškart apsispręsti ir nereikėtų
+klausti papildomai. Rodyk žmogišką pasekmę/naudą (ką tai duoda), ne tik kas
+techniškai daroma. Jei būtinas techninis terminas — paaiškink jį vienu
+sakiniu. Galioja visose sesijose.
+
 ## Modelio parinkimas
 
 Prieš pradėdamas užduotį, ją įvertink:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,7 @@ išbandytas ant geležies (flash'inimui reikia USB kabelio prie PC). Todėl:
 - Planas NEKEIČIAMAS be vartotojo sutikimo. Prieš įkeliant ar keičiant ką
   nors plane, VISADA pirma pasiūlyk vartotojui, ką įtraukti, ir palauk
   patvirtinimo — niekada nekeisk plano savavališkai.
+- PC sesijos pradžioje: peržiūrėk atvirus GitHub issue'us ir pasiūlyk
+  vartotojui, kuriuos kelti į planą (su tuo pačiu sutikimo principu). Taip visų
+  debesų / telegram sesijų fiksuoti darbai per `git pull` + issue'us pasiekia
+  PC be atskiro priminimų sąrašo — issue'ai yra vienintelis „gyvas" šaltinis.

--- a/Firmware_Hosting/feedback-worker.md
+++ b/Firmware_Hosting/feedback-worker.md
@@ -24,6 +24,10 @@ raktų (`panel:*`). HTML įkeliamas iš PC su `wrangler`, NE iš repo.
 
 Proxy į gh-pages (be KV): `/demo`, `/manual`, `/roadmap`.
 
+**SEO / AI-discovery route'ai** (inline turinys `src/index.js`, ne KV — apex neturi
+CNAME, tad worker juos servina pats): `/robots.txt`, `/sitemap.xml`, `/llms.txt`.
+Turinį keisti tiesiai `index.js` + `wrangler deploy`.
+
 **Gating pastaba:** `LIST_KEY` = Worker secret (`wrangler secret put LIST_KEY`);
 `key:team` = KV raktas (vienintelis toks — `wrangler kv key put key:team <secret>`).
 Blogas/nesamas raktas šiuose route'uose grąžina 404 (nematomą), ne 403.

--- a/Firmware_Hosting/feedback-worker/src/index.js
+++ b/Firmware_Hosting/feedback-worker/src/index.js
@@ -80,6 +80,42 @@ export default {
     }
     const path = url.pathname.replace(/\/$/, '') || '/';
 
+    // --- SEO / AI discovery: robots.txt, sitemap.xml, llms.txt at the apex ---
+    // The apex root is Cloudflare-served (not this worker) and there is no CNAME,
+    // so these files have no gh-pages home; the worker owns them via dedicated
+    // routes (see wrangler.jsonc). Kept inline here as the single source of truth.
+    if (request.method === 'GET' && path === '/robots.txt') {
+      const body = 'User-agent: *\nAllow: /\n\nSitemap: https://tinymakerwifi.com/sitemap.xml\n';
+      return new Response(body, {
+        headers: { 'Content-Type': 'text/plain;charset=utf-8', 'Cache-Control': 'public, max-age=86400' },
+      });
+    }
+    if (request.method === 'GET' && path === '/sitemap.xml') {
+      const pages = ['/', '/manual/', '/roadmap/', '/demo/'];
+      const body = '<?xml version="1.0" encoding="UTF-8"?>\n'
+        + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        + pages.map(p => `  <url><loc>https://tinymakerwifi.com${p}</loc></url>`).join('\n')
+        + '\n</urlset>\n';
+      return new Response(body, {
+        headers: { 'Content-Type': 'application/xml;charset=utf-8', 'Cache-Control': 'public, max-age=86400' },
+      });
+    }
+    if (request.method === 'GET' && path === '/llms.txt') {
+      const body = `# TinyMakerWifi
+
+> Open-source firmware that adds WiFi, wireless model upload from PrusaSlicer, a web dashboard, OTA self-updates, resin tracking and phone notifications to the palm-sized TinyMaker MSLA (resin) 3D printer (ESP32-WROOM-32E).
+
+## Docs
+- [User manual](https://tinymakerwifi.com/manual/): WiFi setup, wireless printing from PrusaSlicer, the web dashboard, OTA updates, exposure/resin settings, troubleshooting
+- [Roadmap](https://tinymakerwifi.com/roadmap/): what is coming and what shipped
+- [Live demo](https://tinymakerwifi.com/demo/): the real dashboard driving a simulated printer
+- [Source, releases & firmware downloads](https://github.com/slibbinas/TinyMakerWifi)
+`;
+      return new Response(body, {
+        headers: { 'Content-Type': 'text/plain;charset=utf-8', 'Cache-Control': 'public, max-age=86400' },
+      });
+    }
+
     // Test panel: the per-release physical-test checklist, PUBLIC by design -
     // it is linked from the firmware's pre-release banner and the feedback
     // form, turning every beta user into a structured tester (checklist ->

--- a/Firmware_Hosting/feedback-worker/wrangler.jsonc
+++ b/Firmware_Hosting/feedback-worker/wrangler.jsonc
@@ -14,6 +14,9 @@
     { "pattern": "tinymakerwifi.com/roadmap*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "tinymakerwifi.com/orai*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "tinymakerwifi.com/oi/*", "zone_name": "tinymakerwifi.com" },
+    { "pattern": "tinymakerwifi.com/robots.txt", "zone_name": "tinymakerwifi.com" },
+    { "pattern": "tinymakerwifi.com/sitemap.xml", "zone_name": "tinymakerwifi.com" },
+    { "pattern": "tinymakerwifi.com/llms.txt", "zone_name": "tinymakerwifi.com" },
     // www would otherwise fall through to bare gh-pages: /testai 404'd and
     // /feedback served the form WITHOUT the worker (its POST would go nowhere).
     // The worker owns these paths on www too and 301s to the apex.
@@ -26,7 +29,10 @@
     { "pattern": "www.tinymakerwifi.com/manual*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "www.tinymakerwifi.com/roadmap*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "www.tinymakerwifi.com/orai*", "zone_name": "tinymakerwifi.com" },
-    { "pattern": "www.tinymakerwifi.com/oi/*", "zone_name": "tinymakerwifi.com" }
+    { "pattern": "www.tinymakerwifi.com/oi/*", "zone_name": "tinymakerwifi.com" },
+    { "pattern": "www.tinymakerwifi.com/robots.txt", "zone_name": "tinymakerwifi.com" },
+    { "pattern": "www.tinymakerwifi.com/sitemap.xml", "zone_name": "tinymakerwifi.com" },
+    { "pattern": "www.tinymakerwifi.com/llms.txt", "zone_name": "tinymakerwifi.com" }
   ],
   "kv_namespaces": [
     { "binding": "FEEDBACK", "id": "4eb7904e55fc490e854f85f631e6c35e" }

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>TinyMakerWifi — WiFi firmware for the TinyMaker resin 3D printer</title>
-<meta name="description" content="Open-source firmware that adds WiFi, wireless model upload from PrusaSlicer, a web dashboard, OTA self-updates, resin tracking and phone notifications to the palm-sized TinyMaker MSLA resin printer.">
+<meta name="description" content="Open-source firmware adding WiFi, wireless PrusaSlicer upload, a web dashboard, OTA self-updates and phone alerts to the palm-sized TinyMaker resin 3D printer.">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="TinyMakerWifi">
 <meta property="og:title" content="TinyMakerWifi — WiFi firmware for the TinyMaker resin 3D printer">
@@ -15,6 +15,24 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="TinyMakerWifi — logo and the web dashboard during a print">
 <meta name="twitter:card" content="summary_large_image">
+<link rel="canonical" href="https://tinymakerwifi.com/">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "TinyMakerWifi",
+  "operatingSystem": "ESP32 (TinyMaker MSLA resin 3D printer)",
+  "applicationCategory": "DeveloperApplication",
+  "description": "Open-source firmware that adds WiFi, wireless model upload from PrusaSlicer, a web dashboard, OTA self-updates, resin tracking and phone notifications to the TinyMaker MSLA resin 3D printer.",
+  "url": "https://tinymakerwifi.com/",
+  "image": "https://tinymakerwifi.com/og-card.png",
+  "license": "https://github.com/slibbinas/TinyMakerWifi/blob/main/LICENSE.md",
+  "isAccessibleForFree": true,
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "author": { "@type": "Person", "name": "Viktoras Šidlauskas" },
+  "codeRepository": "https://github.com/slibbinas/TinyMakerWifi"
+}
+</script>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect x='8' y='40' width='48' height='9' rx='3' fill='%23e8720c'/><rect x='14' y='27' width='36' height='9' rx='3' fill='%23e8720c' opacity='.75'/><rect x='20' y='14' width='24' height='9' rx='3' fill='%23e8720c' opacity='.5'/><path d='M22 6 A14 14 0 0 1 42 6' fill='none' stroke='%234da3ff' stroke-width='5' stroke-linecap='round'/></svg>">
 <script>(function(){try{var p=new URLSearchParams(location.search).get('theme');if(p==='light'||p==='dark')localStorage.setItem('tmTheme',p);if((p||localStorage.getItem('tmTheme'))==='light')document.documentElement.setAttribute('data-theme','light')}catch(e){}})()</script>
 <style>
@@ -148,8 +166,8 @@ footer a{color:var(--muted2);text-decoration:underline}
   })();
   </script>
   <div class="shots">
-    <figure><img src="https://slibbinas.github.io/TinyMakerWifi/manual/images/Palm_Sized.jpg" alt="The palm-sized TinyMaker MSLA resin 3D printer"><figcaption>The printer — palm-sized, open source</figcaption></figure>
-    <figure><img src="https://slibbinas.github.io/TinyMakerWifi/landing/dashboard-print.png" alt="The web dashboard during a print: live status, print controls and a real-time 3D render of the print"><figcaption>The dashboard mid-print — live 3D progress, controls, SD manager</figcaption></figure>
+    <figure><img src="https://slibbinas.github.io/TinyMakerWifi/manual/images/Palm_Sized.jpg" alt="The palm-sized TinyMaker MSLA resin 3D printer" width="1000" height="1000" loading="lazy" decoding="async"><figcaption>The printer — palm-sized, open source</figcaption></figure>
+    <figure><img src="https://slibbinas.github.io/TinyMakerWifi/landing/dashboard-print.png" alt="The web dashboard during a print: live status, print controls and a real-time 3D render of the print" width="1394" height="3698" loading="lazy" decoding="async"><figcaption>The dashboard mid-print — live 3D progress, controls, SD manager</figcaption></figure>
   </div>
 </div>
 

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -3,7 +3,44 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>TinyMakerWifi — User Manual</title>
+<title>TinyMakerWifi Manual — WiFi & wireless printing for the TinyMaker resin printer</title>
+<meta name="description" content="Set up and use TinyMakerWifi: WiFi, wireless PrusaSlicer upload, the web dashboard, OTA updates, exposure settings and troubleshooting for the TinyMaker resin 3D printer.">
+<link rel="canonical" href="https://tinymakerwifi.com/manual/">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="TinyMakerWifi">
+<meta property="og:title" content="TinyMakerWifi User Manual">
+<meta property="og:description" content="Set up and use TinyMakerWifi: WiFi, wireless PrusaSlicer upload, the web dashboard, OTA updates and troubleshooting for the TinyMaker resin 3D printer.">
+<meta property="og:url" content="https://tinymakerwifi.com/manual/">
+<meta property="og:image" content="https://tinymakerwifi.com/og-card.png">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "The printer won't connect to WiFi",
+      "acceptedAnswer": { "@type": "Answer", "text": "After 15 seconds it boots offline and SD printing still works. To retry, reset WiFi (System then WiFi Info then OK, or hold Back while powering on) and set it up again." } },
+    { "@type": "Question", "name": "Where do I find the printer's IP address?",
+      "acceptedAnswer": { "@type": "Answer", "text": "On the printer go to System then WiFi Info; it shows the connected network, signal strength and IP. On most networks tinymaker.local works instead of the IP." } },
+    { "@type": "Question", "name": "PrusaSlicer Test fails",
+      "acceptedAnswer": { "@type": "Answer", "text": "Check the printer is on and shows a green dot and an IP under System then WiFi Info. Use that IP if tinymaker.local does not resolve on your network. The API key value does not matter." } },
+    { "@type": "Question", "name": "The dashboard opens but every button is disabled",
+      "acceptedAnswer": { "@type": "Answer", "text": "Web control is off. Turn it back on on the printer: System then Advanced then Web control. Slicer upload and MQTT are unaffected by this switch." } },
+    { "@type": "Question", "name": "My print looks half-height or wrong",
+      "acceptedAnswer": { "@type": "Answer", "text": "Slice with the 0.05 mm profile. At a 0.10 mm setting the printer uses every other image by design." } },
+    { "@type": "Question", "name": "Resin left looks wrong",
+      "acceptedAnswer": { "@type": "Answer", "text": "It is an estimate that only counts confirmed refills. Press VAT refilled after topping up, and keep Ask refill on so it stays honest." } },
+    { "@type": "Question", "name": "A firmware update failed",
+      "acceptedAnswer": { "@type": "Answer", "text": "The dual OTA partition keeps the previous firmware, so the printer should still boot. Try again from System then Update, or upload a firmware.bin from the dashboard Settings then Update." } },
+    { "@type": "Question", "name": "How do I keep my settings through a USB reflash?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Before flashing, open the dashboard, Settings, Backup to SD. After the reflash the printer finds the backup on the SD card and offers to restore it on first boot. Only WiFi needs to be set up again." } },
+    { "@type": "Question", "name": "How do I go fully offline?",
+      "acceptedAnswer": { "@type": "Answer", "text": "System then Advanced then WiFi then Off. The printer behaves like the original firmware; turn WiFi back on in the same place whenever you like." } },
+    { "@type": "Question", "name": "What does the Anonymous usage ping send?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Once per firmware version, on the first boot after a flash, the printer sends a one-way hash of its factory MAC address, the firmware version, and the lifetime print hours. Nothing else: no models, no settings, no network details. To opt out, untick Settings then Network then Anonymous usage ping." } }
+  ]
+}
+</script>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect x='8' y='40' width='48' height='9' rx='3' fill='%23e8720c'/><rect x='14' y='27' width='36' height='9' rx='3' fill='%23e8720c' opacity='.75'/><rect x='20' y='14' width='24' height='9' rx='3' fill='%23e8720c' opacity='.5'/><path d='M22 6 A14 14 0 0 1 42 6' fill='none' stroke='%234da3ff' stroke-width='5' stroke-linecap='round'/><circle cx='47' cy='46' r='16' fill='%231667c9'/><text x='47' y='53' font-family='Arial' font-size='20' font-weight='bold' fill='white' text-anchor='middle'>M</text></svg>">
 <style>
   :root{
@@ -156,7 +193,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
   <h1>TinyMakerWifi</h1>
   <p class="tag">WiFi, wireless upload &amp; over-the-air updates for the TinyMaker resin printer</p>
   <p class="author">by <b>Viktoras Šidlauskas</b> · <a href="https://github.com/slibbinas">@slibbinas</a> · <a href="https://tinymakerwifi.com">tinymakerwifi.com</a></p>
-  <img src="images/Palm_Sized.jpg" alt="The palm-sized TinyMaker MSLA resin 3D printer">
+  <img src="images/Palm_Sized.jpg" alt="The palm-sized TinyMaker MSLA resin 3D printer" width="1000" height="1000" loading="eager" decoding="async">
 </header>
 
 <div class="wrap">
@@ -254,7 +291,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
     <li>Choose your home WiFi network and enter the password.</li>
     <li>The printer connects and briefly shows its IP address. Credentials are stored, so later boots connect on their own in about 5&nbsp;seconds.</li>
   </ol>
-  <img class="shot phone" src="images/wifi-setup-phone.png" alt="The TinyMaker-Setup captive portal as seen on a phone">
+  <img class="shot phone" src="images/wifi-setup-phone.png" alt="The TinyMaker-Setup captive portal as seen on a phone" width="720" height="1170" loading="lazy" decoding="async">
   <p>On every later boot the printer shows <b>animated signal bars</b> while connecting — they turn <b>green</b> when it’s on the network, and the printer goes straight to the main menu (the IP address is only shown after the first-time portal setup). Need the address later? WiFi status, signal strength and IP are always under <b>System → WiFi Info</b>.</p>
   <p>If the saved network can’t be reached, the printer simply boots offline after 15&nbsp;s — printing from the SD card works as always.</p>
 
@@ -269,7 +306,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
 <section>
   <h2 class="sec" id="screens"><span class="num">5</span>The printer screens</h2>
   <p>The small status display drives the whole on-printer interface — WiFi setup, upload progress, the resin estimate, the device toggles and self-update. Three buttons: <kbd>Back</kbd>, <kbd>Up</kbd> and <kbd>OK</kbd>. A green (connected) or grey (offline) dot on the main menu shows WiFi status.</p>
-  <img class="shot" src="images/printer-screens.png" alt="A montage of the TinyMakerWifi printer UI screens">
+  <img class="shot" src="images/printer-screens.png" alt="A montage of the TinyMakerWifi printer UI screens" width="2080" height="2352" loading="lazy" decoding="async">
   <p>The <b>System</b> menu is where the new features live: <b>WiFi Info</b>, <b>Advanced</b> (device toggles, grouped into Network / Resin / Display), <b>Statistics</b> (lifetime counters and the last boot/crash record), <b>Update</b> (firmware) and <b>About</b> (version and build info). The full item-by-item reference is in <a href="#advanced">System menu reference</a>.</p>
 </section>
 
@@ -284,8 +321,8 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
     <li>Slice, then press <b>Send to printer</b>. The printer shows <i>Receiving → Unpacking → Model ready</i>, and the model appears in the <b>Print</b> menu.</li>
   </ol>
   <div class="row">
-    <img class="shot" src="images/prusaslicer-physical-printer.png" alt="PrusaSlicer: adding a physical printer pointing at tinymaker.local">
-    <img class="shot" src="images/prusaslicer-send-to-printer.png" alt="PrusaSlicer: the Send to printer button">
+    <img class="shot" src="images/prusaslicer-physical-printer.png" alt="PrusaSlicer: adding a physical printer pointing at tinymaker.local" width="1200" height="1108" loading="lazy" decoding="async">
+    <img class="shot" src="images/prusaslicer-send-to-printer.png" alt="PrusaSlicer: the Send to printer button" width="1200" height="1108" loading="lazy" decoding="async">
   </div>
   <div class="warn">⚠️ <b>Always slice with the 0.05&nbsp;mm profile.</b> Maximum model size: 1200 layers = 60&nbsp;mm.<br>
   Unlike an FDM slicer, the layer height here is set <b>on the printer</b> (Settings → Layer height), not in the file — the file is just a stack of 0.05&nbsp;mm images, and at the 0.10&nbsp;mm setting the firmware exposes every other one. Slice at anything else and the part comes out the wrong height: at 0.3&nbsp;mm it would be six times too short.</div>
@@ -333,12 +370,12 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
   <p>Open the printer’s IP address in any browser for the full dashboard: live print status and controls, SD-card management with one-click start/import, device settings and firmware updates — in tabs styled to match the printer. The <b>◐ crescent</b> next to the <i>Manual</i> link switches between the <b>light and dark theme</b> (your choice sticks per browser), and small <b>?</b> marks next to the tricky settings open short explanations.</p>
   <div class="note">🧪 No printer at hand? <a href="https://tinymakerwifi.com/demo/">Try the dashboard live</a> — the same UI driving a simulated printer: start a print, watch the 3D progress, poke through Settings.</div>
   <div class="note">💬 The <b>Feedback</b> link in the header opens a 30-second form — what works, what doesn't, what's missing. Photos are welcome (a failed print says more than a paragraph) and your firmware version comes along automatically. No account, and it genuinely steers what gets built next.</div>
-  <img class="shot" src="images/web-dashboard.png" alt="The TinyMakerWifi web dashboard: live status, controls and SD manager">
+  <img class="shot" src="images/web-dashboard.png" alt="The TinyMakerWifi web dashboard: live status, controls and SD manager" width="1120" height="1600" loading="lazy" decoding="async">
   <h3>While a print runs</h3>
   <p>The state line counts the current step down — <b>Curing · 9s</b>, <b>Lifting · 4s</b> — and after <b>Stop</b> or a finished print it counts the ride to the top the same way, so that wait finally has a number. Next to it a small dot says whether the printer answered just now (green) or is mid-move (amber, <i>syncing</i>).</p>
   <p>That dot is worth understanding, because it explains something that looks like a fault. One ESP32 runs the screen, the motor, the UV LED and this web server, all off a single SD card — so the page is served in the gaps between layer moves. During the peel the printer deliberately answers nothing: a pause there could mark the part. <b>A few seconds of amber is the printer working, not the page hanging.</b> The SD card is locked for the same reason — uploads and file actions come back when the print ends, and the model list stays readable throughout.</p>
   <p>On a larger screen it spreads into two columns:</p>
-  <img class="shot" src="images/dashboard-idle.png" alt="The dashboard on a desktop screen: status card with UV LED time and the Manual link, SD manager with models">
+  <img class="shot" src="images/dashboard-idle.png" alt="The dashboard on a desktop screen: status card with UV LED time and the Manual link, SD manager with models" width="1379" height="1520" loading="lazy" decoding="async">
   <p>New to the printer? A dismissible <b>Getting Started</b> checklist on the dashboard walks you through the first steps (WiFi → slicer → first model → first print → exposure calibration → integrations) — the printer ticks steps off by itself where it can.</p>
   <p><b>Put it on your phone's home screen:</b> open the dashboard in the phone browser and pick <i>Add to Home screen</i> (Chrome: the ⋮ menu; iPhone Safari: Share → <i>Add to Home Screen</i>). You get the printer's icon on the home screen, and on iPhone it opens fullscreen like an app. (A browser "install" banner won't appear — the printer serves plain HTTP on your LAN — but the shortcut works the same.)</p>
 
@@ -359,7 +396,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
   <p>The card itself is always on the dashboard, like the SD manager: before anything is previewed it shows a <i>Pick a model and press Preview</i> hint, and the last previewed model is remembered — a page reload brings it straight back from the saved preview (no re-render, nothing to redo).</p>
   <p><b>Resin on the info line:</b> when the exact amount is known it is shown outright; otherwise a quick <code>~X&nbsp;ml (quick)</code> estimate appears with the preview, free of charge. Clicking the <code>~</code> value runs the <b>exact scan on the printer</b> — it decodes every layer, so expect roughly a minute per 100 layers.</p>
   <p>Start a print (from the row’s <b>Start</b> or on the printer) and the same card takes over automatically as a <b>live progress render</b>: the printed part fills in with color, the rest stays a ghost outline. It costs the printer nothing (the browser renders from a few prefetched layers).</p>
-  <img class="shot" src="images/printing-eta.png" alt="The dashboard while printing: status with remaining time and finish-time estimate, print controls and the live 3D progress render">
+  <img class="shot" src="images/printing-eta.png" alt="The dashboard while printing: status with remaining time and finish-time estimate, print controls and the live 3D progress render" width="1394" height="1130" loading="lazy" decoding="async">
 
   <h3>The Settings tab</h3>
   <p>Settings is split into five sections, switched by underline tabs — <b>Print / Network / Notifications / Boot animation / Backup</b> — shown one at a time, each with its own <b>Save config</b> button (saving from any section preserves the other sections’ values):</p>
@@ -450,7 +487,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
     <li><b>Set it:</b> pick the <b>lowest time that still cures sharp and sturdy</b> (best detail; if torn between two, take the longer one) and enter it as <b>Regular exposure</b> in Settings. Identify bars by their dots (1 dot = shortest) and read the time from the table above. Keep <b>Base exposure</b> at roughly 2.5× the new Regular — it’s about first-layer adhesion, not detail.</li>
   </ol>
   <figure style="margin:16px 0 6px">
-    <img class="shot" src="images/exposure-test-strip.jpg" alt="A real exposure test strip cured in the vat: eight bars with dot markers, holes crisp on the long-exposure side and sealing over toward the short side">
+    <img class="shot" src="images/exposure-test-strip.jpg" alt="A real exposure test strip cured in the vat: eight bars with dot markers, holes crisp on the long-exposure side and sealing over toward the short side" width="1280" height="1073" loading="lazy" decoding="async">
     <figcaption>A real test strip in the vat — count the dots: bar N carries N holes, so flipping or mirroring never confuses it. On the long-exposure side the holes cured round and open; toward the short side the bars turn translucent and the holes seal over. Pick the lowest bar whose holes are still open and edges sharp.</figcaption>
   </figure>
   <div class="note">💡 Cold resin cures slower — run the test at the temperature you actually print at. Check the vat for leftovers afterwards; a <i>Clean Resin Vat</i> cycle picks up anything you missed.</div>
@@ -471,7 +508,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
     <li><b>On the printer:</b> System → Advanced → Display → <b>Boot animation</b> — <kbd>OK</kbd> cycles <i>Default</i> (the built-in logo), <i>Shuffle</i> and every installed animation.</li>
     <li><b>In the dashboard:</b> Settings → the <b>Boot animation</b> tab. Picking a row only <b>stages</b> the choice — press <b>Save config</b> to apply it. <b>Show</b> plays any installed animation on the printer’s screen right away (only while the printer is idle), and <b>Delete</b> removes its file from the SD card.</li>
   </ul>
-  <img class="shot" src="images/boot-animations.png" alt="Settings, Boot animation tab: installed animations with Show and Delete, the staged selection and Save config">
+  <img class="shot" src="images/boot-animations.png" alt="Settings, Boot animation tab: installed animations with Show and Delete, the staged selection and Save config" width="1394" height="1451" loading="lazy" decoding="async">
   <p><b>Shuffle</b> (offered once two or more animations are installed) plays a random installed animation on every boot.</p>
   <p>Getting new animations onto the printer:</p>
   <ul>
@@ -481,6 +518,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
   </ul>
   <div class="note">💡 <b>Keep animations short — 2–4 seconds is the sweet spot.</b> The firmware hard-caps playback at 250 frames or 10 seconds (whichever comes first), and pressing <kbd>Back</kbd> skips the animation immediately.</div>
   <p><i>Boot animations were contributed by <a href="https://github.com/Tann2019">Tanner Steorts (@Tann2019)</a>; Shuffle by <a href="https://github.com/Briadark">Brian Karmelk (@Briadark)</a>.</i></p>
+</section>
 
 <section>
   <h2 class="sec" id="update"><span class="num">12</span>Updating the firmware</h2>
@@ -491,7 +529,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
     <li><b>From the dashboard — Settings → Update:</b> installed vs latest with an <b>Install latest</b> button, a <b>version picker</b> (install any released version; downgrades ask to confirm) and a <b>file upload</b> for a <code>firmware.bin</code>.</li>
     <li><b>For developers:</b> PlatformIO OTA via the <code>tinymaker-ota</code> environment (open System → Update on the printer first — that path keeps the strict gate).</li>
   </ul>
-  <img class="shot" src="images/firmware-update-page.png" alt="The dashboard Settings > Update pane: installed vs latest, install latest, version picker and file upload">
+  <img class="shot" src="images/firmware-update-page.png" alt="The dashboard Settings > Update pane: installed vs latest, install latest, version picker and file upload" width="1120" height="1330" loading="lazy" decoding="async">
   <p>Two comforts while updating: the printer also <b>checks by itself</b> — shortly after WiFi connects at boot it looks for a newer version and shows <i>“Update available — Install / Later”</i> on the screen (choosing Later offers to turn the check off; the switch lives in System → Advanced → Network → Boot update and in dashboard Settings). And when you start an install from the browser, the dashboard locks under an <b>“Updating firmware”</b> overlay and <b>reloads itself</b> when the printer is back — no guessing whether it finished.</p>
   <div class="note">✅ <b>Don’t worry about a failed update.</b> The printer keeps two firmware copies (dual OTA partition), so a failed flash falls back to the previous one. Just don’t power off mid-update.</div>
 
@@ -505,7 +543,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
   </ul>
   <p><b>Auto backup to TinyMaker Connect</b> (optional, for registered Connect users): a checkbox under Settings → <b>Network</b> → <i>TinyMaker Connect</i> keeps a backup on the Connect server after settings changes and after prints; the Backup tab then offers <b>Download from Connect</b> and <b>Restore from Connect</b>. Connect backups do <b>not</b> include the stored MQTT, notification or Connect secrets. When you register, save the <b>recovery code</b> (Retrieve / Copy buttons in the Connect section) — it restores your Connect profile if you ever reset the printer without a backup.</p>
   <div class="note">💡 WiFi credentials are managed separately (by the WiFi setup portal) and are <b>not</b> in the backup — after a full USB reflash you reconnect to WiFi once, everything else restores. The backup includes your MQTT password, so treat the file accordingly.</div>
-  <img class="shot" src="images/settings-backup.png" alt="The Settings tab with the Backup &amp; restore buttons: Download backup, Backup to SD, Restore from file">
+  <img class="shot" src="images/settings-backup.png" alt="The Settings tab with the Backup &amp; restore buttons: Download backup, Backup to SD, Restore from file" width="1379" height="572" loading="lazy" decoding="async">
 </section>
 
 <section>


### PR DESCRIPTION
Pilnas SEO/našumo/LLM optimizavimas svetainei. **Ne firmware** — HTML (docs/) + Cloudflare Worker. Nereikia kompiliuoti/flash.

## Kas padaryta (4 commit'ai)

**1. Landing (`docs/landing/index.html`)** — jau turėjo gerą title/OG, pridėta:
- `rel=canonical`
- **`SoftwareApplication` JSON-LD** (free/open-source, repo, licencija)
- meta description sutrumpinta ~155 simb.
- `width/height` + `loading=lazy` + `decoding=async` abiem nuotraukom (mažina CLS)

**2. Manual (`docs/manual/index.html`)** — anksčiau beveik jokio SEO:
- keyword-rich `<title>`, meta description, **Open Graph** + twitter card, canonical
- **`FAQPage` JSON-LD** iš esamos Troubleshooting/FAQ (10 Q&A) — kandidatas į Google rich results
- `width/height` + `loading` + `decoding` visoms 12 nuotraukų (hero `eager` kaip LCP, kitos `lazy`)
- **pataisytas neuždarytas `<section>`** (12 sekcija nebesikabinėja po 11)

**3. Worker (`feedback-worker/src/index.js` + `wrangler.jsonc`)** — apex neturi CNAME, tad SEO failai serverinami per Worker route'us:
- `/robots.txt` → allow all + `Sitemap:` nuoroda
- `/sitemap.xml` → `/`, `/manual/`, `/roadmap/`, `/demo/`
- `/llms.txt` → trumpas LLM-facing aprašymas + doc nuorodos
- route'ai pridėti `wrangler.jsonc` (apex + www); JS syntax patikrintas (`node --check`)

**4.** `feedback-worker.md` — dokumentuoti nauji route'ai.

## Verifikacija (jau atlikta)
- JSON-LD abu galioja (`json.loads` OK: SoftwareApplication + FAQPage)
- `<section>` balansas 15/15
- Worker `node --check` OK
- Nuotraukų `width/height` = tikros pikselių dimensijos

## ⚠️ Deployment (PC, ne debesys)
1. **HTML** (`docs/landing`, `docs/manual`) → įkelti į `gh-pages` (kaip visada).
2. **Worker** → `cd Firmware_Hosting/feedback-worker && npx wrangler deploy`.
3. Po deploy: `curl https://tinymakerwifi.com/robots.txt` ir `/sitemap.xml`; Google Rich Results Test ant `/` ir `/manual/`; pateikti sitemap Google Search Console.

Debesų sesija to nedeployina — tik parašo kodą.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XZTq7yBae5NZqFivw7GSS)_