### PR TITLE
landing+manual: add theme-color meta (light/dark)

### DIFF
--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="theme-color" media="(prefers-color-scheme:dark)" content="#141416">
+<meta name="theme-color" media="(prefers-color-scheme:light)" content="#f2f2f4">
 <title>TinyMakerWifi — WiFi firmware for the TinyMaker resin 3D printer</title>
 <meta name="description" content="Open-source firmware adding WiFi, wireless PrusaSlicer upload, a web dashboard, OTA self-updates and phone alerts to the palm-sized TinyMaker resin 3D printer.">
 <meta property="og:type" content="website">

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" media="(prefers-color-scheme:dark)" content="#141416">
+<meta name="theme-color" media="(prefers-color-scheme:light)" content="#f2f2f4">
 <title>TinyMakerWifi Manual — WiFi & wireless printing for the TinyMaker resin printer</title>
 <meta name="description" content="Set up and use TinyMakerWifi: WiFi, wireless PrusaSlicer upload, the web dashboard, OTA updates, exposure settings and troubleshooting for the TinyMaker resin 3D printer.">
 <link rel="canonical" href="https://tinymakerwifi.com/manual/">


### PR DESCRIPTION
Smulkus polish iš UX peržiūros. Ne firmware — tik docs (landing + manual).

Pridedami `<meta name="theme-color">` su light/dark variantais: mobilios naršyklės viršaus juostą nuspalvina puslapio tema (dark `#141416` / light `#f2f2f4`) vietoj numatytosios.

Kiti UX peržiūros radiniai (ne šiame PR):
- `dashboard.html` `<html lang>` — prijungta prie #50 (firmware asset, flash).
- `og-card.png` egzistavimas live'e — patikrinti (tik vartotojas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017XZTq7yBae5NZqFivw7GSS)_