### PR TITLE
docs: feedback links to /tests (not legacy /testai)

### DIFF
--- a/docs/feedback/index.html
+++ b/docs/feedback/index.html
@@ -106,7 +106,7 @@ else document.addEventListener('DOMContentLoaded',tmWireToggle);
   <form id="f">
     <h1>Tell us how it's going</h1>
     <p>What works, what doesn't, what's missing — anything helps. It goes straight to the people building the firmware. No account, ~30 seconds. <span id="fwLine" class="fw"></span></p>
-    <p>Testing a beta? <a href="/testai?lang=en">Walk the test checklist</a> first — its report pastes right in here.</p>
+    <p>Testing a beta? <a href="/tests?lang=en">Walk the test checklist</a> first — its report pastes right in here.</p>
     <label for="msg">Your feedback</label>
     <textarea id="msg" required maxlength="4000" placeholder="e.g. The exposure test saved me an evening... / Upload fails when..."></textarea>
     <label for="pics">Photos (optional, up to 3) — a failed print says more than a paragraph</label>


### PR DESCRIPTION
The feedback page's "Walk the test checklist" link pointed at the legacy `/testai` path (which the worker only 301-redirects). Points it at `/tests` directly, matching the English path. Fixed in repo + live gh-pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)