### PR TITLE
docs: manual - Chrome/Edge callout for web flashing

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -226,6 +226,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
 
   <h3>Method 1 — the web flasher (recommended)</h3>
   <p><a href="https://connect.tinymakerwifi.com/flash.php"><b>connect.tinymakerwifi.com/flash.php</b></a> flashes the latest release straight from your browser — nothing to download or install:</p>
+  <div class="note">🌐 <b>Use Chrome or Edge.</b> Web (USB) flashing needs the Web&nbsp;Serial API — Firefox and Safari don’t support it.</div>
   <ol class="steps">
     <li>Connect the printer to your computer via USB.</li>
     <li>Open the web flasher in <b>Chrome or Edge</b> (they support Web Serial; Firefox and Safari don’t).</li>


### PR DESCRIPTION
One-line docs change. Promotes the existing in-step Web Serial note under **Method 1 (web flasher)** to an up-front callout, so first-timers see the browser requirement immediately.

**Why:** a 0.16.1 clean-install feedback note reported Firefox web-flashing didn't work (expected — Firefox/Safari lack the Web Serial API). Already live on gh-pages (`beebe55`); this syncs the repo source on `main`.

Low risk (docs only, no firmware/build impact). Mirror of experimental `caf1a59`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)