### PR TITLE
docs: ROADMAP.md - 0.17 adds live 3D progress + flat-print guard

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ the repo never carries a second copy of the feature lists that drifts out of dat
 | **0.15.8** | current **stable** — what the automatic self-update installs |
 | **0.16.0** | shipped as a **beta** (*Update → version picker*), headlined by **power-loss resume** — the printer picks a print back up after an outage, or safely lifts the plate, answerable from your phone |
 | **0.16.x** | **now** — beta stabilization: fixes from tester feedback, then it is promoted to the automatic self-update channel |
-| **0.17** | next — the exposure wave: sub-second exposure timing and named resin profiles |
+| **0.17** | next — the feature wave: sub-second exposure timing and named resin profiles, live 3D progress on every device, and a flat-print guard |
 | **1.0.0** | 0.17, promoted once it has proven itself |
 
 New builds ship first as **betas** (from the [Releases page](https://github.com/slibbinas/TinyMakerWifi/releases)


### PR DESCRIPTION
Syncs main's canonical `ROADMAP.md` with the live public roadmap (gh-pages, already pushed) and experimental. One-line, high-level; per-beta detail stays out per policy.

Low risk (docs only, no firmware/build impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)