### PR TITLE
firmware(0.17): LH-chk flat-print guard (#63)

### DIFF
--- a/include/ModelImport.h
+++ b/include/ModelImport.h
@@ -8,6 +8,7 @@ struct ModelSummary {
   float heightMm = 0;
   uint32_t estimatedSecs = 0;
   uint32_t sizeBytes = 0;
+  float slicedLayerHeightMm = 0;  // from the archive's config.ini; 0 = unknown
 };
 
 struct ModelImportOptions {

--- a/src/Import.ino
+++ b/src/Import.ino
@@ -137,12 +137,31 @@ int countImportModelSourceLayers(const String &name) {
   return count;
 }
 
+// Read a numeric INI value ("key = value") from a null-terminated text buffer.
+// Returns 0 if the key is absent. Matches the key only as a whole token (start
+// of buffer or after whitespace/newline, then optional spaces, then '='), so
+// "layerHeight" is not matched inside a longer key. Modeled on backupNum().
+float iniReadNumber(const char *text, const char *key) {
+  size_t keyLen = strlen(key);
+  const char *p = text;
+  while ((p = strstr(p, key)) != NULL) {
+    bool startOk = (p == text) || p[-1] == '\n' || p[-1] == '\r' ||
+                   p[-1] == ' ' || p[-1] == '\t';
+    const char *q = p + keyLen;
+    while (*q == ' ' || *q == '\t') q++;
+    if (startOk && *q == '=') return (float)atof(q + 1);  // atof skips spaces, stops at newline
+    p += keyLen;  // not a whole-token match; keep searching
+  }
+  return 0.0f;
+}
+
 bool scanZipModel(const char *zipPath, ModelSummary &summary) {
   char entry[256];
   UNZIP *zip = new UNZIP();
   if (!zip) return false;
 
   int minN = 0x7FFFFFFF, total = 0;
+  float slicedLH = 0.0f;
   if (zip->openZIP(zipPath, zipOpen, zipClose, zipRead, zipSeek) != UNZ_OK) {
     delete zip;
     return false;
@@ -154,6 +173,22 @@ bool scanZipModel(const char *zipPath, ModelSummary &summary) {
     if (n >= 0) {
       total++;
       if (n < minN) minN = n;
+    } else if (slicedLH == 0.0f) {
+      // The SL1/ZIP config.ini carries the sliced layerHeight. Read it once,
+      // bounded, into a stack buffer (config.ini is small); parse one key.
+      String en = String(entry);
+      en.toLowerCase();
+      if (en.endsWith("config.ini") && zip->openCurrentFile() == UNZ_OK) {
+        char cfg[1024];
+        int off = 0, rc;
+        while (off < (int)sizeof(cfg) - 1 &&
+               (rc = zip->readCurrentFile((uint8_t *)cfg + off,
+                                          sizeof(cfg) - 1 - off)) > 0)
+          off += rc;
+        zip->closeCurrentFile();
+        cfg[off] = '\0';
+        slicedLH = iniReadNumber(cfg, "layerHeight");
+      }
     }
   } while (zip->gotoNextFile() == UNZ_OK);
   zip->closeZIP();
@@ -161,6 +196,7 @@ bool scanZipModel(const char *zipPath, ModelSummary &summary) {
 
   if (!modelSummaryFromSourceLayers(total, summary)) return false;
   summary.sizeBytes = sdFileSize(String(zipPath));
+  summary.slicedLayerHeightMm = slicedLH;
   return true;
 }
 
@@ -225,6 +261,10 @@ bool writeModelMetadataFile(const String &destDir, const String &name,
   f.print(",\n");
   f.print("  \"archive_size_bytes\": ");
   f.print(summary.sizeBytes);
+  if (summary.slicedLayerHeightMm > 0) {
+    f.print(",\n  \"sliced_layer_height_mm\": ");
+    f.print(String(summary.slicedLayerHeightMm, 3));
+  }
   if (options.resinKnown) {
     f.print(",\n  \"resin_ml\": ");
     f.print(String(options.resinMl, 2));
@@ -422,6 +462,19 @@ bool getModelMetadataResin(const String &name, double &resinMl) {
   String json;
   if (!readModelMetadataJson(name, json)) return false;
   return readJsonNumberField(json, "resin_ml", resinMl);
+}
+
+bool getModelMetadataSlicedLayerHeight(const String &name, double &mm) {
+  String json;
+  if (!readModelMetadataJson(name, json)) return false;
+  return readJsonNumberField(json, "sliced_layer_height_mm", mm);
+}
+
+// "Flat print" risk: the firmware assumes source PNGs are 0.05 mm pitch, so any
+// other sliced layer height comes out wrong (usually flat). 0 = unknown (no
+// config.ini / old model) -> not flagged.
+bool slicedIsFlat(float mm) {
+  return mm > 0.0f && (mm < 0.049f || mm > 0.051f);
 }
 
 bool getModelMetadataConnectPublicId(const String &name, String &publicId) {
@@ -659,6 +712,10 @@ void importSelectedArchive() {
   if (ok) {
     SD.remove(src.c_str());
     netMessage("Model ready:", result.finalName.c_str());
+    if (slicedIsFlat(result.summary.slicedLayerHeightMm)) {
+      delay(1500);
+      netMessage("Not sliced at 0.05mm!", "Prints may be flat");
+    }
   } else {
     netMessage("Import FAILED", foldersel.c_str());
   }

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -785,7 +785,10 @@ bool modelSummaryForModel(const String &name, ModelSummary &summary) {
     sourceLayers = countModelSourceLayers(name);
     backfillModelMetadataLayers(name, sourceLayers);  // pay the scan once
   }
-  return modelSummaryFromSourceLayers(sourceLayers, summary);
+  if (!modelSummaryFromSourceLayers(sourceLayers, summary)) return false;
+  double lh = 0;
+  if (getModelMetadataSlicedLayerHeight(name, lh)) summary.slicedLayerHeightMm = (float)lh;
+  return true;
 }
 
 bool modelStats(const String &name, int &printLayers, float &heightMm, uint32_t &timeSecs) {
@@ -1081,7 +1084,11 @@ void handleApiFileModel() {
   out += String(summary.estimatedSecs);
   out += ",\"estimatedTime\":\"";
   out += formatDuration(summary.estimatedSecs);
-  out += "\",\"preview\":";
+  out += "\",\"slicedLayerHeightMm\":";
+  out += String(summary.slicedLayerHeightMm, 3);
+  out += ",\"flatWarning\":";
+  out += slicedIsFlat(summary.slicedLayerHeightMm) ? "true" : "false";
+  out += ",\"preview\":";
   bool preview05 = sdPathExists("/" + name + "/preview05.png");
   bool preview1 = sdPathExists("/" + name + "/preview1.png");
   bool previewLegacy = sdPathExists("/" + name + "/preview.png");
@@ -3164,6 +3171,10 @@ void sdJobRun() {
     if (ok) {
       sdRev++;  // 0-28: every dashboard refreshes its list and names the model
       netMessage("Model ready:", result.finalName.c_str());
+      if (slicedIsFlat(result.summary.slicedLayerHeightMm)) {
+        delay(1500);
+        netMessage("Not sliced at 0.05mm!", "Prints may be flat");
+      }
     } else {
       DBGLN("SD job import FAILED");
       netMessage("Import FAILED", sdJobName.c_str());

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -137,6 +137,7 @@
     <div><div class='label'>Estimated time</div><div id='modelTime' class='value'>-</div></div>
     <div id='modelResinBox' class='hidden'><div class='label'>Resin needed</div><div id='modelResin' class='value'>-</div></div>
   </div>
+  <div id='modelFlatWarn' class='hidden' style='margin-top:10px;padding:10px 12px;border-radius:8px;background:rgba(232,160,32,.15);border:1px solid #e8a020;color:#e8a020;font-size:13px'>&#9888; Sliced at <b><span id='modelFlatVal'>?</span>&nbsp;mm</b>, not 0.05&nbsp;mm &mdash; the printer assumes 0.05&nbsp;mm, so this may print <b>flat</b>. Re-slice with a 0.05&nbsp;mm layer height.</div>
   <div id='modelProgress' class='progress hidden'><span></span></div>
   <div id='modelActions' class='actions'>
     <button id='modelBackButton' class='button secondary spanAll' type='button'>Back to dashboard</button>
@@ -1135,6 +1136,7 @@ const modelDetails=async(nameEnc,estimate)=>{
     setText('modelTitle',d.name); setText('modelLayers',d.layers); setText('modelHeight',Number(d.heightMm).toFixed(2)+' mm'); setText('modelTime',d.estimatedTime);
     const showPrint=d.printLayers!==undefined&&Number(d.printLayers)!==Number(d.layers);
     show('modelPrintLayersBox',showPrint); if(showPrint)setText('modelPrintLayers',d.printLayers);
+    show('modelFlatWarn',!!d.flatWarning); if(d.flatWarning)setText('modelFlatVal',Number(d.slicedLayerHeightMm).toFixed(2));
     // Resin box is always there: exact value when known, otherwise the quick
     // estimate lands with the auto preview render below ("Estimating...").
     show('modelResinBox',true);


### PR DESCRIPTION
**0.17 Sprint A — LH-chk (flat-print guard, #63).** Warns when an uploaded SL1/ZIP was sliced at a layer height other than 0.05 mm, instead of silently printing flat (FB/Patryk).

## What changed
- **`iniReadNumber()`** + `config.ini` parse in `scanZipModel` (`src/Import.ino`): bounded 1023-byte read of the archive's `config.ini` into a stack buffer; whole-token key match; missing/garbage → 0 (unknown).
- **`ModelSummary.slicedLayerHeightMm`** (`include/ModelImport.h`); persisted in `model.json` (`sliced_layer_height_mm`, only when >0); read back via `getModelMetadataSlicedLayerHeight`.
- **`handleApiFileModel`** exposes `slicedLayerHeightMm` + `flatWarning` (distinct from the printer's `layerHeight` setting).
- **LCD warning** after "Model ready" (`sdJobRun` + `importSelectedArchive`) — non-blocking.
- **Dashboard**: amber flat-warning banner on the model card (`web/dashboard.html`).

**Non-blocking**: the model still imports/prints; unknown height (no config.ini / old model) → no warning (backward-compatible).

## Verification done
- INI parse logic: **13/13** Python cases (substring guard, missing key, garbage, 1023-byte truncation safety).
- **`firmware-auditor`: clean** — no correctness or security bugs; verified buffer safety (no overflow/OOB), pointer walk, whole-token match, data flow, backward-compat, dashboard JS. (Untrusted-parse buffer safety = the security-review surface for this change.)
- `pio run -e tinymaker` **SUCCESS**; flash +~1 KB (well within F-opt's reclaimed headroom); no RAM increase.

## ⚠️ DO NOT MERGE until hardware-tested (firmware → manual merge only)
- [ ] Upload a **0.05 mm** model → imports clean, **no** warning.
- [ ] Upload a model sliced at **0.10 mm** → **flat warning** on LCD + dashboard + `flatWarning:true` from `/api/files/model`.
- [ ] A model with no `config.ini` → no false warning.

Base: `experimental`. Draft — CI only compiles, can't test on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
