### PR TITLE
firmware(0.17): CT crash telemetry (#70) + /crash worker endpoint

### DIFF
--- a/Firmware_Hosting/feedback-worker/src/index.js
+++ b/Firmware_Hosting/feedback-worker/src/index.js
@@ -57,6 +57,8 @@ const PAGE = 25;                            // notes fetched in full per view
 const MAX_PER_IP_DAY = 5;
 const MAX_PER_DAY = 60;
 const DAY_TTL = 172800;                     // counters self-clean after 48 h
+const MAX_CRASH_PER_DAY = 200;             // crash pings are rare + firmware-deduped; cap guards a runaway fleet
+const CRASH_TTL = 60 * 60 * 24 * 90;       // crash records self-clean after 90 days
 
 const str = (v, n) => String(v || '').slice(0, n);
 
@@ -312,6 +314,48 @@ export default {
       });
     }
 
+    // Firmware crash telemetry (GitHub #70): anonymous, opt-out on the device.
+    // NOT a browser form -> no Turnstile; the firmware de-dupes per crash event,
+    // and here a per-device 60 s gate + a daily cap + a bounded JSON parse keep a
+    // crashlooping or hostile device from flooding KV. No IP, no personal data -
+    // just a hashed device id + the ESP reset reason (+ optional layer/epoch).
+    if (path === '/crash' && request.method === 'POST') {
+      let f = {};
+      try { f = await request.json(); } catch (e) {
+        return new Response('bad body', { status: 400 });
+      }
+      const id = str(f.id, 64);
+      const reason = str(f.reason, 48);
+      if (!id || !reason) return new Response('bad', { status: 400 });
+
+      const gate = 'cgate:' + id;                 // 1 crash / 60 s / device
+      if (await env.FEEDBACK.get(gate))
+        return new Response('slow down', { status: 429 });
+      const day = new Date().toISOString().slice(0, 10);
+      const allKey = `cday:${day}`;
+      const allUsed = Number(await env.FEEDBACK.get(allKey)) || 0;
+      if (allUsed >= MAX_CRASH_PER_DAY)
+        return new Response('over daily limit', { status: 503 });
+      await env.FEEDBACK.put(gate, '1', { expirationTtl: 60 });
+      await env.FEEDBACK.put(allKey, String(allUsed + 1), { expirationTtl: DAY_TTL });
+
+      const stamp = new Date().toISOString();
+      const rec = {
+        id,
+        version: str(f.version, 20),
+        reason,
+        layer: Math.max(0, Math.min(60000, Number(f.layer) || 0)),
+        epoch: Math.max(0, Number(f.epoch) || 0),
+        at: stamp,
+      };
+      await env.FEEDBACK.put('crash:' + stamp + ':' + id.slice(0, 8),
+                             JSON.stringify(rec),
+                             { metadata: { reason: rec.reason, version: rec.version },
+                               expirationTtl: CRASH_TTL });
+      return new Response(JSON.stringify({ ok: true }),
+                         { headers: { 'Content-Type': 'application/json' } });
+    }
+
     // 0-7 PUBLIC ticket status: the token IS the authorisation - unguessable
     // (uuid), and a wrong one answers 404 with no timing-relevant difference.
     // Only status fields go back out - never the message or the contact (a
@@ -500,6 +544,28 @@ export default {
       });
     }
 
+    // Crash telemetry admin view (same LIST_KEY as the feedback inbox).
+    if ((path === '/crash/inbox' || path === '/crash/list') && keyOk) {
+      const names = [];
+      let ccur;
+      do {
+        const page = await env.FEEDBACK.list({ prefix: 'crash:', limit: 1000, cursor: ccur });
+        for (const k of page.keys) names.push(k.name);
+        ccur = page.list_complete ? null : page.cursor;
+      } while (ccur);
+      names.reverse();                              // newest first
+      const recs = [];
+      for (const k of names.slice(0, 500)) {
+        const v = await env.FEEDBACK.get(k);
+        if (v) recs.push(JSON.parse(v));
+      }
+      if (path === '/crash/list')
+        return new Response(JSON.stringify(recs, null, 1),
+                           { headers: { 'Content-Type': 'application/json' } });
+      return new Response(crashInboxPage(recs),
+                         { headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-store' } });
+    }
+
     if (path === '/feedback/img' && keyOk) {
       const k = url.searchParams.get('k') || '';
       if (!k.startsWith('img:')) return new Response('bad key', { status: 400 });
@@ -526,6 +592,30 @@ const when = (iso) => {
   if (isNaN(d)) return esc(iso);
   const p = (n) => (n < 10 ? '0' : '') + n;
   return `${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())} UTC`;
+};
+
+// Crash telemetry inbox (GitHub #70): read behind LIST_KEY. Anonymous rows -
+// hashed device id + ESP reset reason (+ optional print layer). esc() on every
+// field: reason/version come off the wire from firmware.
+const crashInboxPage = (recs) => {
+  const counts = {};
+  for (const r of recs) counts[r.reason] = (counts[r.reason] || 0) + 1;
+  const summary = Object.entries(counts).sort((a, b) => b[1] - a[1])
+    .map(([k, n]) => `<span class="pill">${esc(k)}: <b>${n}</b></span>`).join(' ')
+    || '<span class="sub">no reports</span>';
+  const rows = recs.map((r) =>
+    `<tr><td>${when(r.at)}</td><td>${esc(r.reason)}</td><td>${esc(r.version)}</td>` +
+    `<td>${r.layer ? esc(String(r.layer)) : ''}</td><td class="mono">${esc(String(r.id).slice(0, 8))}</td></tr>`
+  ).join('');
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>TinyMaker crash telemetry</title>
+<style>body{font:14px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;margin:0;background:#1c1c1e;color:#eee;padding:20px}
+h1{font-size:19px;color:#e8720c;margin:0 0 4px}.sub{color:#aaa;font-size:13px;margin-bottom:14px}
+.pill{display:inline-block;background:#3a2a10;border:1px solid #e8a020;color:#e8a020;border-radius:12px;padding:2px 10px;margin:2px;font-size:12px}
+table{border-collapse:collapse;width:100%;margin-top:14px}th,td{text-align:left;padding:7px 10px;border-bottom:1px solid #333;font-size:13px}
+th{color:#aaa;font-weight:600;font-size:12px}.mono{font-family:ui-monospace,monospace;color:#84bcf8}tr:hover td{background:#242426}</style></head>
+<body><h1>Crash telemetry</h1><div class="sub">${recs.length} report(s) &middot; anonymous (hashed device id + ESP reset reason). Newest first, 90-day retention.</div>
+<div>${summary}</div>
+<table><tr><th>When</th><th>Reason</th><th>Version</th><th>Layer</th><th>Device</th></tr>${rows}</table></body></html>`;
 };
 
 const contactLink = (c) => {

--- a/Firmware_Hosting/feedback-worker/wrangler.jsonc
+++ b/Firmware_Hosting/feedback-worker/wrangler.jsonc
@@ -5,6 +5,7 @@
   "compatibility_date": "2026-07-01",
   "routes": [
     { "pattern": "tinymakerwifi.com/feedback*", "zone_name": "tinymakerwifi.com" },
+    { "pattern": "tinymakerwifi.com/crash*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "tinymakerwifi.com/testai*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "tinymakerwifi.com/tests*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "tinymakerwifi.com/plan*", "zone_name": "tinymakerwifi.com" },
@@ -22,6 +23,7 @@
     // /feedback served the form WITHOUT the worker (its POST would go nowhere).
     // The worker owns these paths on www too and 301s to the apex.
     { "pattern": "www.tinymakerwifi.com/feedback*", "zone_name": "tinymakerwifi.com" },
+    { "pattern": "www.tinymakerwifi.com/crash*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "www.tinymakerwifi.com/testai*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "www.tinymakerwifi.com/tests*", "zone_name": "tinymakerwifi.com" },
     { "pattern": "www.tinymakerwifi.com/plan*", "zone_name": "tinymakerwifi.com" },

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -83,6 +83,7 @@ bool rejectIfBusy() {
 // (2) the direct HTTPS URL of that firmware.bin. Both hosted on GitHub Pages.
 #define OTA_VERSION_URL "https://slibbinas.github.io/TinyMakerWifi/version.txt"
 #define STATS_PING_URL  "https://tinymaker-stats.slibbinas.workers.dev/ping"
+#define CRASH_PING_URL  "https://tinymakerwifi.com/crash"   // anonymous crash telemetry (feedback worker, opt-out)
 
 WebServer server(80);
 Preferences netPrefs;
@@ -2354,6 +2355,60 @@ void statsPingMaybe() {
   }
 }
 
+// Was the last boot an abnormal reset (crash), as opposed to a clean power-on
+// or software restart? (0-30 telemetry names live in resetReasonName().)
+bool isAbnormalReset() {
+  switch (bootResetReason) {
+    case ESP_RST_PANIC:
+    case ESP_RST_INT_WDT:
+    case ESP_RST_TASK_WDT:
+    case ESP_RST_WDT:
+    case ESP_RST_BROWNOUT: return true;
+    default:               return false;
+  }
+}
+
+// Anonymous crash telemetry (GitHub #70): report a mid-print death (crashSeen)
+// or any abnormal reset, so the maintainer sees fleet-wide instability without
+// waiting for a user report. Same opt-out as the install ping (statsPingEnabled)
+// and the same anonymous hashed id - no IP, name or model data. De-duped per
+// crash event (crashSeen/crashReason persist across boots, so a marker keeps us
+// from re-sending the same crash on every reboot). Called once from setup().
+void crashPingMaybe() {
+  if (!statsPingEnabled || WiFi.status() != WL_CONNECTED) return;
+  if (!crashSeen && !isAbnormalReset()) return;   // nothing worth reporting
+
+  uint8_t  rsn   = crashSeen ? crashReason : (uint8_t)bootResetReason;
+  uint16_t layer = crashSeen ? crashLayer  : 0;   // layer/epoch only meaningful
+  uint32_t epoch = crashSeen ? crashEpoch  : 0;   // for a mid-print death
+  String eventId = String(epoch) + ":" + String(rsn) + ":" + String(layer);
+
+  sysPrefs.begin("tinymaker", true);
+  String reported = sysPrefs.getString("crashPingId", "");
+  sysPrefs.end();
+  if (reported == eventId) return;                // already sent this event
+
+  WiFiClientSecure client;
+  client.setInsecure();
+  HTTPClient http;
+  if (!http.begin(client, CRASH_PING_URL)) return;
+  http.setTimeout(5000);
+  http.addHeader("Content-Type", "application/json");
+  String body = "{\"id\":\"" + statsHardwareHash() +
+                "\",\"version\":\"" + connectFirmwareVersion() +
+                "\",\"reason\":\"" + String(resetReasonName(rsn)) +
+                "\",\"layer\":" + String(layer) +
+                ",\"epoch\":" + String(epoch) + "}";
+  int code = http.POST(body);
+  http.end();
+  if (code >= 200 && code < 300) {
+    sysPrefs.begin("tinymaker", false);
+    sysPrefs.putString("crashPingId", eventId);
+    sysPrefs.end();
+    DBGLN("Crash ping sent");
+  }
+}
+
 // Download a firmware image over HTTPS and flash it. Shows progress on the
 // LCD; reboots on success. Shared by "Install latest" and the version picker.
 void otaFlashUrl(const String &url, const char *subtitle) {
@@ -3112,6 +3167,7 @@ void network_setup() {
     delay(1800);
   }
   statsPingMaybe();
+  crashPingMaybe();
   otaBootCheckMaybePrompt();
   if (screen == 424) return;
 }


### PR DESCRIPTION
**0.17 Sprint A — CT (crash telemetry, #70).** Aggregates abnormal resets / mid-print deaths across the fleet so instability is visible before the October batch, instead of waiting for user reports.

## What changed
- **Firmware `src/Network.ino`**: `crashPingMaybe()` (+ `isAbnormalReset()`) posts an anonymous crash report to the feedback worker `/crash` on `crashSeen` (a print died unexpectedly) or an abnormal reset (panic/brownout/watchdog). Payload: hashed device id + reset reason + layer + epoch — **no IP/name/model**. Same `statsPingEnabled` opt-out as the install ping. **De-duped per crash event** via NVS `crashPingId` so a reboot never re-sends the same crash. Called once from `network_setup()` (boot, off the print path — like `statsPingMaybe`).
- **Worker `Firmware_Hosting/feedback-worker`**: `POST /crash` (bounded parse, per-device 60s gate + daily cap + 90-day TTL) + `GET /crash/inbox?key=LIST_KEY` (esc'd render, count-by-reason). Route added in `wrangler.jsonc`. **Already deployed.**
- Worker chosen over the stats worker (whose source isn't in the repo); piggyback-on-install-ping dropped (would've gone to the untouched stats worker).

## Verification done
- **`firmware-auditor`: clean** (dedup, print-path safety, opt-out, privacy, JSON, prototypes).
- **`/security-review`: clean** — no HIGH/MED (esc'd render, bounded parse, key-gated inbox, no PII).
- **Worker end-to-end** (curl): POST→200, gate→429, bad-body→400, key-gated inbox→404.
- **Hardware end-to-end**: power-loss mid-print → crash-ping landed in `/crash/inbox` (correct anonymous payload); **dedup confirmed** (idle reboot → no new record, no spurious fire). It even caught a real brownout-during-resume as a distinct event.
- `pio run -e tinymaker` **SUCCESS**; +~2.1 KB flash; no RAM increase.

## Notes
- Hardware-tested on the printer (build `8d82962`). Merge after review.
- Known minor (auditor, by design): a pure abnormal-reset crashloop of the same reason reports once until the reason changes (avoids spam).

Base: `experimental`. Draft — CI only compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
