### PR TITLE
P-live: live 3D progress in every browser (0.17 Sprint B)

### DIFF
--- a/src/Network.ino
+++ b/src/Network.ino
@@ -2010,6 +2010,63 @@ void handleApiPrintStop() {
   sendApiOk("\"stopping\":true");
 }
 
+// Base64 of a byte buffer into out (caller sizes it: len*4/3 + pad + nul).
+static void liveBase64(const uint8_t *in, int len, char *out) {
+  static const char T[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  int o = 0;
+  for (int i = 0; i < len; i += 3) {
+    uint32_t n = (uint32_t)in[i] << 16;
+    if (i + 1 < len) n |= (uint32_t)in[i + 1] << 8;
+    if (i + 2 < len) n |= in[i + 2];
+    out[o++] = T[(n >> 18) & 63];
+    out[o++] = T[(n >> 12) & 63];
+    out[o++] = (i + 1 < len) ? T[(n >> 6) & 63] : '=';
+    out[o++] = (i + 2 < len) ? T[n & 63] : '=';
+  }
+  out[o] = 0;
+}
+
+// GET /api/live/slices?since=k - the P-live 3D stack (0.17). View-only and
+// RAM-only (no SD touch), so - unlike /api/files/layer - it is allowed to answer
+// mid-print: that is the whole point, a browser opened while printing gets the
+// growing 3D here. Returns the 64x48 1-bit silhouettes captured so far in slots
+// [since, captured); the browser delta-fetches when status.liveCaptured grows.
+// Streamed chunked so the worst case (36 slices ~= 18 KB) never allocates a big
+// String on the print-time heap.
+void handleApiLiveSlices() {
+  bool live = printerBusy() && liveBuf && liveN > 0;
+  int cap = live ? liveCaptured : 0;
+  int since = server.hasArg("since") ? server.arg("since").toInt() : 0;
+  if (since < 0) since = 0;
+  if (since > cap) since = cap;
+  float modelH = live ? layer_counter * Layer_Height : 0;
+
+  server.setContentLength(CONTENT_LENGTH_UNKNOWN);   // chunked
+  server.send(200, "application/json", "");
+  String head = "{\"ok\":true,\"live\":";
+  head += live ? "true" : "false";
+  head += ",\"gw\":";       head += String(LIVE_GW);
+  head += ",\"gh\":";       head += String(LIVE_GH);
+  head += ",\"n\":";        head += String(live ? liveN : 0);
+  head += ",\"captured\":"; head += String(cap);
+  head += ",\"since\":";    head += String(since);
+  head += ",\"layers\":";   head += String(live ? layer_counter : 0);
+  head += ",\"modelH\":";   head += String(modelH, 2);
+  head += ",\"model\":\"";  head += jsonEscape(live ? String(foldersel_long) : String(""));
+  head += "\",\"slices\":[";
+  server.sendContent(head);
+  char b64[LIVE_SLICE_BYTES * 4 / 3 + 8];   // 384 -> 512 chars + nul
+  for (int k = since; k < cap; k++) {
+    liveBase64(liveBuf + (size_t)k * LIVE_SLICE_BYTES, LIVE_SLICE_BYTES, b64);
+    server.sendContent(k > since ? ",\"" : "\"");
+    server.sendContent(b64);
+    server.sendContent("\"");
+  }
+  server.sendContent("]}");
+  server.sendContent("");   // terminate the chunked body
+}
+
 void handleApiStatus() {
   bool busy = printerBusy();
   bool connected = WiFi.status() == WL_CONNECTED;
@@ -2138,6 +2195,12 @@ void handleApiStatus() {
   out += String(statusCurrentLayer);
   out += ",\"totalLayers\":";
   out += String(statusTotalLayers);
+  // P-live: how many 3D silhouettes the printer has captured so far. A browser
+  // with no local slices polls /api/live/slices when liveCaptured grows.
+  out += ",\"liveN\":";
+  out += String(busy ? liveN : 0);
+  out += ",\"liveCaptured\":";
+  out += String(busy ? liveCaptured : 0);
   out += ",\"layerText\":\"";
   out += String(statusCurrentLayer) + " / " + String(statusTotalLayers);
   out += "\",\"resinUsedMl\":";
@@ -3075,6 +3138,7 @@ void network_setup() {
   server.on("/api/files/model/preview", HTTP_GET, handleApiFileModelPreview);
   server.on("/api/files/model/preview", HTTP_POST, finishPreviewUpload, handlePreviewUploadData);
   server.on("/api/files/layer", HTTP_GET, handleApiFileLayer);
+  server.on("/api/live/slices", HTTP_GET, handleApiLiveSlices);   // P-live 3D stack
   server.on("/api/files/delete", HTTP_POST, handleApiFileDelete);
   server.on("/api/config", HTTP_GET, handleApiConfigGet);
   server.on("/api/config", HTTP_POST, handleApiConfigSave);

--- a/src/PNG.ino
+++ b/src/PNG.ino
@@ -10,6 +10,60 @@ bool estimateCancelReq = false;       // Back pressed during the estimate scan
 double resinUsedMl = 0.0;             // grows while printing
 double resinEstimateMl = 0.0;         // filled by estimateResin()
 
+// ===================================================================================
+// P-live: per-layer silhouette capture for live 3D in EVERY browser (0.17)
+// ===================================================================================
+// A layer is already decoded pixel-by-pixel to expose it. On the ~36 layers the
+// dashboard samples for its isometric render we fold that same pass into a tiny
+// 64x48 1-bit silhouette and keep the growing stack in RAM. Any browser -
+// including one opened mid-print, which cannot read layer PNGs off the locked SD
+// card - fetches the stack from /api/live/slices and grows the identical 3D.
+// The sampling mirrors dashboard.html fetchSlices(): N = min(36, layer_counter),
+// slice k = logical layer 1 + round(k*(layer_counter-1)/(N-1)). The buffer lives
+// only for the duration of one print (freed at its single exit).
+// LIVE_* and the shared globals (liveBuf/liveN/liveCaptured) live in
+// TinyMaker.ino - it is concatenated before Network.ino, which must see them to
+// serve /api/live/slices (this PNG.ino comes last, after both). The state below
+// is used only here, so it stays local.
+int liveNextK = 0;        // next slot to fill
+int liveNextLayer = 0;    // logical layer that fills liveNextK (0 = none pending)
+static int liveSlot = -1; // slot PNGDraw is filling right now (-1 = not capturing)
+static int liveSrcW = 0, liveSrcH = 0;  // active layer's source dims, for scaling
+
+// Logical layer (1-based) whose silhouette fills slot k - mirrors the JS sampler.
+int liveSampleLayer(int k) {
+  if (liveN <= 1) return 1;
+  return 1 + (int)lroundf((float)k * (layer_counter - 1) / (float)(liveN - 1));
+}
+
+void liveClear() {
+#if ENABLE_NETWORK
+  if (liveBuf) { free(liveBuf); liveBuf = NULL; }
+  liveN = liveCaptured = liveNextK = liveNextLayer = 0;
+  liveSlot = -1;
+#endif
+}
+
+// Called once at print start (total = layer_counter). Allocates the stack; on a
+// failed alloc the feature just stays off (liveBuf NULL) and the print is normal.
+void liveBegin(int total) {
+#if ENABLE_NETWORK
+  liveClear();
+  if (total < 1) return;
+  liveN = total < LIVE_MAX_SLICES ? total : LIVE_MAX_SLICES;
+  liveBuf = (uint8_t *)calloc((size_t)liveN, LIVE_SLICE_BYTES);
+  if (!liveBuf) { liveN = 0; return; }
+  // Skip sample heights at or below the current layer: a resumed print starts at
+  // resumeLayer, and those layers are already printed (their PNGs stay unread -
+  // no SD mid-print). Fresh print: current_layer is 0, so nothing is skipped and
+  // the first target is layer 1. Without this the sampler waits for layer 1
+  // forever on resume and captures nothing (audit M1).
+  liveNextK = 0;
+  while (liveNextK < liveN && liveSampleLayer(liveNextK) <= current_layer) liveNextK++;
+  liveNextLayer = liveNextK < liveN ? liveSampleLayer(liveNextK) : 0;
+#endif
+}
+
 void * myOpen(const char *filename, int32_t *size) {
   myfile = SD.open(filename);
   *size = myfile.size();
@@ -47,13 +101,35 @@ void PNGDraw(PNGDRAW *pDraw) {
   // Count "lit" (white) pixels for resin estimation. A simple luminance
   // test on the unpacked RGB565 channels works fine here since slices are
   // pure black/white. Threshold ~50%.
+#if ENABLE_NETWORK
+  // P-live: on a sampled layer, fold this scanline into the 64x48 silhouette.
+  // liveSlot >= 0 only inside print_next_png()'s capture window, so the estimate
+  // and preview decode passes (liveBuf NULL / liveSlot -1) never touch it.
+  bool liveCap = (liveSlot >= 0 && liveBuf && liveSrcW > 0 && liveSrcH > 0);
+  uint8_t *liveRow = NULL;
+  int liveSy = 0;
+  if (liveCap) {
+    liveSy = (int)((long)pDraw->y * LIVE_GH / liveSrcH);
+    if (liveSy < 0) liveSy = 0; else if (liveSy >= LIVE_GH) liveSy = LIVE_GH - 1;
+    liveRow = liveBuf + (size_t)liveSlot * LIVE_SLICE_BYTES;
+  }
+#endif
   for (int x = 0; x < pDraw->iWidth; x++) {
     uint16_t p = usPixels[x];
     uint8_t r = (p >> 11) & 0x1F;
     uint8_t g = (p >> 5) & 0x3F;
     uint8_t b = p & 0x1F;
     // normalize to 0..255-ish and test brightness
-    if (((r << 3) + (g << 2) + (b << 3)) / 3 > 128) whitePixelsAccum++;
+    bool lit = (((r << 3) + (g << 2) + (b << 3)) / 3 > 128);
+    if (lit) whitePixelsAccum++;
+#if ENABLE_NETWORK
+    if (liveCap && lit) {
+      int sx = (int)((long)x * LIVE_GW / liveSrcW);
+      if (sx < 0) sx = 0; else if (sx >= LIVE_GW) sx = LIVE_GW - 1;
+      int cell = liveSy * LIVE_GW + sx;              // silhouette cell (row-major)
+      liveRow[cell >> 3] |= (uint8_t)(1 << (cell & 7));   // LSB-first bit packing
+    }
+#endif
   }
   if (!countPixelsMode)
     gfx1->draw16bitRGBBitmap(0, pDraw->y + 0, usPixels, pDraw->iWidth, 1);    // Draw to display (skip when only counting)
@@ -85,11 +161,41 @@ void print_next_png(){
   FileName.toCharArray(NameChar, 110);
   int rc;
   whitePixelsAccum = 0;
+#if ENABLE_NETWORK
+  // P-live: is this logical layer one of the sampled heights? Decided before the
+  // decode; the sampler is advanced AFTER it whether or not the slice was
+  // actually captured, so an unreadable sample PNG (or bad dims) can't stall the
+  // rest of the print (audit M2). current_layer climbs by 1 per layer, so it
+  // hits each target exactly once.
+  bool liveSampleNow = (liveBuf && liveNextK < liveN && current_layer == liveNextLayer);
+#endif
   rc = png.open((const char *)NameChar, myOpen, myClose, myRead, mySeek, PNGDraw);
   if (rc == PNG_SUCCESS) {
+#if ENABLE_NETWORK
+    liveSlot = -1;
+    if (liveSampleNow) {
+      liveSrcW = png.getWidth();
+      liveSrcH = png.getHeight();
+      if (liveSrcW > 0 && liveSrcH > 0) {
+        liveSlot = liveNextK;
+        memset(liveBuf + (size_t)liveSlot * LIVE_SLICE_BYTES, 0, LIVE_SLICE_BYTES);
+      }
+    }
+#endif
     rc = png.decode(NULL, 0);
     png.close();
+#if ENABLE_NETWORK
+    if (liveSlot >= 0 && liveSlot + 1 > liveCaptured)
+      liveCaptured = liveSlot + 1;   // publish the freshly filled slot
+    liveSlot = -1;
+#endif
   }
+#if ENABLE_NETWORK
+  if (liveSampleNow) {   // advance past this sample even if the capture was skipped
+    liveNextK++;
+    liveNextLayer = liveNextK < liveN ? liveSampleLayer(liveNextK) : 0;
+  }
+#endif
   // Accumulate cured-resin volume for this layer (ml)
   resinUsedMl += (double)whitePixelsAccum * PX_AREA_MM2 * Layer_Height / 1000.0;
   //entry.close();

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -473,6 +473,18 @@ byte estimated_minutes;
 float motor_updown_time;       // Time taken for one up and down cycle
 float motor_updown_time_total; // Total time spent on motor movements
 
+// P-live shared state (0.17): the live-3D silhouette stack. Defined here (the
+// first-concatenated file) so Network.ino can serve it from /api/live/slices and
+// PNG.ino - both concatenated after this one - can fill it. See PNG.ino for the
+// capture logic and the LIVE_* geometry.
+#define LIVE_GW 64
+#define LIVE_GH 48
+#define LIVE_MAX_SLICES 36
+#define LIVE_SLICE_BYTES ((LIVE_GW * LIVE_GH + 7) / 8)   // 384 bytes, 1 bit/px
+uint8_t *liveBuf = NULL;   // LIVE_SLICE_BYTES * liveN, calloc'd per print (NULL = off)
+int liveN = 0;             // sampled slices for this print (<= 36)
+int liveCaptured = 0;      // slots filled so far (grows as the print proceeds)
+
 // UI Navigation Variables
 int setting_item;              // Current selected item in settings menu
 bool setting_item_updown = 1;  // Direction indicator for settings (1=up, 0=down)
@@ -1891,10 +1903,16 @@ void loop() {
         }
         }
 
+        // P-live: allocate the per-print silhouette stack before the first
+        // layer decode, so every browser - including one opened mid-print, which
+        // cannot read the locked SD - can grow the live 3D. No-op without
+        // network; freed at the print's single exit (next to resumeClear).
+        if (!homing_canceled && !print_canceled) liveBegin(layer_counter);
+
         // -------------------------------------------------------------------------------
         // Printing Loop
         // -------------------------------------------------------------------------------
-        while(!homing_canceled && !print_canceled){            
+        while(!homing_canceled && !print_canceled){
           estimated_seconds = 0;
           estimated_hours = 0;
           estimated_minutes = 0;
@@ -2199,6 +2217,7 @@ void loop() {
         resumeClear();     // the checkpoint only outlives an unfinished print
         #if ENABLE_NETWORK
         freePreviewCache();          // 0-19: the RAM preview lives only for the print
+        liveClear();                 // P-live: free the per-print silhouette stack
         #endif
         #if ENABLE_NETWORK
         // A homing abort/error arrives here with print_canceled still false -

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -924,6 +924,12 @@ const applyStatus=s=>{
     // earlier Preview 3D) - zero printer traffic while printing. A page
     // refresh restores them from localStorage.
     if(busyPrint&&s.model&&(slicesCache.name!==s.model||!slicesCache.slices.length))restoreSlicesFromStorage(s.model);
+    // P-live: a new print restarts the printer's stack from 0 - drop a stale
+    // live cache so the kickoff below refetches from scratch.
+    if(slicesCache.mode==='live'&&s.liveCaptured!==undefined&&s.liveCaptured<liveHave){liveHave=0;slicesCache={name:'',mode:'',slices:[],gw:80,gh:60,modelH:0,layers:0};}
+    // Opened mid-print with no local slices, but the printer is streaming its
+    // own 3D stack - pull it so this window grows the identical live 3D.
+    if(busyPrint&&s.model&&s.liveN>0&&(slicesCache.name!==s.model||!slicesCache.slices.length))fetchLiveSlices(s.model,0);
     if(busyPrint&&s.model&&s.totalLayers>0&&slicesCache.name===s.model&&slicesCache.slices.length){
       setDashPreviewName('');  // the print takes the card over from an idle preview
       $('printPreviewTitle').textContent='Print progress 3D';
@@ -932,6 +938,9 @@ const applyStatus=s=>{
       const frac=Math.min(1,s.currentLayer/s.totalLayers);
       $('printPreviewBarFill').style.width=Math.round(frac*100)+'%';  // smooth, every poll
       if(Math.abs(frac-lastPrevFrac)>=0.004){lastPrevFrac=frac;drawIso($('printPreviewCanvas'),frac);}
+      // P-live delta: the printer captured new silhouettes since our last pull -
+      // fetch just those and force a redraw (one new slice may not move % enough).
+      if(slicesCache.mode==='live'&&s.liveCaptured>liveHave)fetchLiveSlices(s.model,liveHave).then(ok=>{if(ok){lastPrevFrac=-1;drawIso($('printPreviewCanvas'),frac);}});
     }else{
       // The card is always up now (like the SD manager). Idle: placeholder
       // when nothing is previewed. Busy without slices (print started on the
@@ -956,14 +965,22 @@ const applyStatus=s=>{
         const cf=s.totalLayers>0?Math.min(1,s.currentLayer/s.totalLayers):0;
         $('printPreviewBarFill').style.width=Math.round(cf*100)+'%';
         $('printPreviewTitle').textContent='Printing · '+Math.round(cf*100)+'%';
-        $('prevNote').textContent='Live 3D print progress isn’t available here — open Preview before starting a print to see it.';
-        show('prevNote',true);
-        // Fill the canvas once (guarded): the RAM snapshot if the printer kept
-        // one, otherwise a plain placeholder.
-        if(busyPreviewShown!==s.model){
-          busyPreviewShown=s.model;
-          if(s.previewCached)loadSavedPreviewTo($('printPreviewCanvas'),s.model).catch(()=>paintPreviewProgress($('printPreviewCanvas'),'Preview not available',null));
-          else paintPreviewProgress($('printPreviewCanvas'),'Preview not available',null);
+        if(s.liveN>0){
+          // P-live is streaming: the fetch kicked off above will populate the
+          // slices and the branch above renders the live 3D within a poll or two.
+          // Brief loading state - no "unavailable" note (this device CAN show it).
+          show('prevNote',false);
+          if(busyPreviewShown!=='live:'+s.model){busyPreviewShown='live:'+s.model;paintPreviewProgress($('printPreviewCanvas'),'Loading live 3D…',cf);}
+        }else{
+          $('prevNote').textContent='Live 3D print progress isn’t available here — open Preview before starting a print to see it.';
+          show('prevNote',true);
+          // Fill the canvas once (guarded): the RAM snapshot if the printer kept
+          // one, otherwise a plain placeholder.
+          if(busyPreviewShown!==s.model){
+            busyPreviewShown=s.model;
+            if(s.previewCached)loadSavedPreviewTo($('printPreviewCanvas'),s.model).catch(()=>paintPreviewProgress($('printPreviewCanvas'),'Preview not available',null));
+            else paintPreviewProgress($('printPreviewCanvas'),'Preview not available',null);
+          }
         }
       }
     }
@@ -1168,6 +1185,7 @@ const PREV_W=720,PREV_H=420,PREV_S=4.6,PREV_CX=360,PREV_CY=272;
 const isoPt=(x,y,z)=>({X:PREV_CX+(x-y)*0.866*PREV_S,Y:PREV_CY+(x+y)*0.35*PREV_S-z*0.8*PREV_S});
 let slicesCache={name:'',mode:'',slices:[],gw:80,gh:60,modelH:0,layers:0};
 let lastPrevFrac=-1;
+let liveHave=0,liveFetching=false;   // P-live: silhouettes pulled from the printer
 let busyPreviewShown='';   // 0-19: model whose RAM-cached preview this page already fetched mid-print
 const loadSavedPreview=name=>loadSavedPreviewTo($('modelPreviewCanvas'),name);
 const loadSavedPreviewTo=async(cv,name)=>{
@@ -1348,6 +1366,37 @@ const restoreSlicesFromStorage=name=>{
     slicesCache={name:o.name,mode:o.mode||'',slices:slices,gw:o.gw,gh:o.gh,modelH:o.modelH,layers:o.layers};
     return true;
   }catch(e){return false;}
+};
+// P-live: unpack a base64 64x48 1-bit silhouette into a 1-byte-per-cell array
+// (LSB-first, matching the firmware's liveBase64/bit packing).
+const unpackLiveSlice=(b64,cells)=>{
+  const bin=atob(b64),s=new Uint8Array(cells);
+  for(let c=0;c<cells;c++)if((bin.charCodeAt(c>>3)>>(c&7))&1)s[c]=1;
+  return s;
+};
+// Pull the printer's own live 3D stack (works mid-print - RAM only, no SD). A
+// full fetch (since=0) rebuilds slicesCache padded to the model's N sampled
+// heights, empty slots for layers not yet printed; a delta merges new slots.
+const fetchLiveSlices=async(model,since)=>{
+  if(liveFetching)return false;
+  liveFetching=true;
+  try{
+    const d=await api('/api/live/slices?since='+since,null,8000);
+    if(!d||!d.live||d.model!==model||!d.n)return false;
+    const cells=d.gw*d.gh;
+    if(since===0||slicesCache.name!==model||slicesCache.mode!=='live'||slicesCache.slices.length!==d.n){
+      const slices=[];for(let k=0;k<d.n;k++)slices.push(new Uint8Array(cells));
+      slicesCache={name:model,mode:'live',slices:slices,gw:d.gw,gh:d.gh,modelH:d.modelH,layers:d.layers};
+      liveHave=0;
+    }
+    for(let j=0;j<d.slices.length;j++){
+      const idx=d.since+j;
+      if(idx>=0&&idx<slicesCache.slices.length)slicesCache.slices[idx]=unpackLiveSlice(d.slices[j],cells);
+    }
+    if(d.captured>liveHave)liveHave=d.captured;
+    return true;
+  }catch(e){return false;}
+  finally{liveFetching=false;}
 };
 let fetchSlicesSeq=0;
 const fetchSlices=async(name,layers,modelH,btn,mode)=>{


### PR DESCRIPTION
Live-growing 3D print progress now renders in **every** open browser/device, not just the one that opened Preview before the print.

## Problem
The growing 3D was local to the browser that pre-downloaded the sampled layers. A window opened mid-print couldn't read layers off the SD (locked while printing) → static snapshot + percent only. #1 recurring feedback, cuts against the "watch from your phone" promise. **1.0.0-mandatory** criterion.

## How
The printer already decodes every layer to expose it. On the ~36 sampled heights (same sampler as the dashboard) it folds that pass into a 64×48 1-bit silhouette in a per-print RAM stack (~13.8 KB, freed at exit) and serves it at a new `GET /api/live/slices` (RAM-only, no SD → answers mid-print). Any browser pulls it and grows the identical 3D; delta-fetches as it grows.

- `PNG.ino` — capture in PNGDraw + print_next_png + liveBegin/liveClear/liveSampleLayer (resume-safe, no sampler stall)
- `Network.ino` — `/api/live/slices` (base64 packed, `?since`) + liveN/liveCaptured in `/api/status`
- `TinyMaker.ino` — LIVE_* + shared globals (first TU), liveBegin before loop, liveClear at exit
- `web/dashboard.html` — pull + grow live 3D when busy with no local slices; delta-fetch

Additive: pre-download path unchanged.

## Gate (before hardware)
- ✅ Compiles — Flash 70.0%, RAM static 30.9%
- ✅ firmware-auditor clean (memory/bounds/single-thread/concatenation/sampler); M1/M2 resume-stall found + fixed
- ✅ Manual security review of the new endpoint (view-only, RAM-only, no PII, LAN-trust consistent)

## Hardware test ✅ (dry-run, build cc829eb)
- liveN=36, capturing at the correct sample layers (1·5·10·14·19…), no stall
- Heap healthy: free ~96 KB, min 77 KB with liveBuf live
- **Incognito window opened mid-print rendered the growing 3D** ("Print progress 3D", voxels growing, 12% printed) — proof of the P-live path (an incognito window has no other slice source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)