### PR TITLE
Resume: granular mid-motion checkpoints + Balanced/Precise toggle (0.17 Sprint B, 1-38+1-38b)

### DIFF
--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -610,7 +610,7 @@ int advancedGroupItemCount(int g) {
     if (wifiEnabled && advancedMqttConfigured()) count++;
     return count;
   }
-  if (g == 2) return 7;  // VAT refilled, pause, warn, ask refill, power resume, exp test, dry run
+  if (g == 2) return 8;  // VAT refilled, pause, warn, ask refill, power resume, resume mode, exp test, dry run
   if (g == 3) return 2;  // idle timeout, boot animation
   return 0;
 }
@@ -626,8 +626,8 @@ int advancedGroupItem(int g, int pos) {
     return 8;                                                 // Boot update (last)
   }
   if (g == 2) {
-    const int items[7] = {3, 4, 5, 6, 13, 9, 2};  // refilled, pause, warn, ask, power resume, exp test, dry run
-    if (pos >= 1 && pos <= 7) return items[pos - 1];
+    const int items[8] = {3, 4, 5, 6, 13, 14, 9, 2};  // refilled, pause, warn, ask, power resume, resume mode, exp test, dry run
+    if (pos >= 1 && pos <= 8) return items[pos - 1];
   }
   if (g == 3) {
     if (pos == 1) return 1;   // Idle timeout
@@ -654,6 +654,7 @@ String advancedLabel(int item) {
   if (item == 11) return "Web control";  // shown only via the Network group,
   if (item == 12) return "MQTT";         // which gates them on wifiEnabled
   if (item == 13) return "Power resume"; // 0-34: power-loss resume on/off
+  if (item == 14) return "Resume mode";  // 0.17 1-38b: Balanced vs Precise checkpoint cadence
   return "";
 }
 
@@ -678,6 +679,7 @@ String advancedValue(int item) {
   if (item == 11) return webDashboardEnabled ? "On" : "Off";
   if (item == 12) return mqttEnabled ? "On" : "Off";
   if (item == 13) return resumeEnabled ? "On" : "Off";
+  if (item == 14) return resumePrecise ? "Precise" : "Balanced";
   return "";
 }
 
@@ -793,6 +795,8 @@ void advancedOptionsSelect() {
     mqttEnabled = !mqttEnabled;
   } else if (id == 13) {
     resumeEnabled = !resumeEnabled;
+  } else if (id == 14) {
+    resumePrecise = !resumePrecise;   // 0.17 1-38b: Balanced <-> Precise checkpoint cadence
   }
   saveDeviceConfig();
   #if ENABLE_NETWORK

--- a/src/Motor.ino
+++ b/src/Motor.ino
@@ -118,6 +118,12 @@ void lift_print(){
   stepper.enableOutputs();
   stepper.move(lift_print_steps_total);
   unsigned long liftNetTs = 0;
+  // 0.17 1-38b: granular power-loss checkpoints during the lift. The plate is
+  // RISING, so its actual height is always >= any earlier sample - recording it
+  // verbatim keeps the safety invariant (live <= true height) AND gives sub-mm
+  // resume instead of the pessimistic pre-lift low. Cadence: Balanced vs Precise.
+  unsigned long liftCkptTs = 0;
+  unsigned long resumeCkptMs = resumePrecise ? RESUME_CKPT_MS_PRECISE : RESUME_CKPT_MS_BALANCED;
   while (stepper.distanceToGo()!= 0){
     #if ENABLE_NETWORK
     // Lift takes seconds and used to serve no network at all - browser
@@ -128,6 +134,12 @@ void lift_print(){
       network_loop();
     }
     #endif
+    // Fires on the first iteration before the first run() (plate still at the
+    // base, so live == base == the old pre-lift 'M'); later ones track the rise.
+    if (resumeEnabled && !print_canceled && millis() - liftCkptTs >= resumeCkptMs) {
+      liftCkptTs = millis();
+      resumeCheckpointLive('M', resumeCycleBaseSteps, stepper.currentPosition());
+    }
     if (stepper.distanceToGo()==lift_print_steps_fast){
       stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60);
     }
@@ -211,6 +223,16 @@ void lower_print(){
   stepper.enableOutputs();
   stepper.move(lower_print_steps);
   unsigned long lowerNetTs = 0;
+  // 0.17 1-38b: granular checkpoints during the DROP. The plate DESCENDS, so a
+  // verbatim reading could sit ABOVE the next real position -> recovery could
+  // drive DOWN into the FEP. Bias `live` DOWN by the furthest one cadence window
+  // can travel (x2 safety) so live <= true height always holds (the plate is
+  // frozen whenever stepper.run() is not called, so descent per window is
+  // bounded by v_max x cadence). Worst-case resume overshoot ~= dropMargin.
+  unsigned long lowerCkptTs = 0;
+  unsigned long resumeCkptMs = resumePrecise ? RESUME_CKPT_MS_PRECISE : RESUME_CKPT_MS_BALANCED;
+  long dropMargin = (long)ceilf((Drop_Back_Feedrate * steps_mm / 60.0f) * (resumeCkptMs / 1000.0f) * 2.0f);
+  if (dropMargin < 8) dropMargin = 8;
   while (stepper.distanceToGo()!= 0){
     #if ENABLE_NETWORK
     if (millis() - lowerNetTs > 300) {   // same as lift_print - see above
@@ -218,6 +240,17 @@ void lower_print(){
       network_loop();
     }
     #endif
+    // NB: NOT gated on print_canceled. The drop loop runs to completion even
+    // after a mid-drop cancel, so `live` MUST keep refreshing through that
+    // descent - otherwise a stale (higher) live + a power loss before the 'E'
+    // write would let resume drive DOWN into the FEP (audit HIGH). A cancelled
+    // print's record is cleared at the print's exit anyway (resumeClear).
+    if (resumeEnabled && millis() - lowerCkptTs >= resumeCkptMs) {
+      lowerCkptTs = millis();
+      long live = stepper.currentPosition() - dropMargin;   // down-biased, safe while descending
+      if (live < 0) live = 0;
+      resumeCheckpointLive('M', resumeCycleBaseSteps, live);
+    }
     stepper.run();
     Duration2 = millis()-startTime2;
     if (Duration2 >= 500 && digitalRead(buttonUp) == LOW && screen == 1111 && print_canceled == false && print_paused == false){

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -1366,6 +1366,8 @@ String configJson() {
   out += bootUpdateCheckEnabled ? "true" : "false";
   out += ",\"resumeEnabled\":";
   out += resumeEnabled ? "true" : "false";
+  out += ",\"resumePrecise\":";
+  out += resumePrecise ? "true" : "false";
   out += ",\"statsPing\":";
   out += statsPingEnabled ? "true" : "false";
   out += ",\"mqttEnabled\":";
@@ -1423,6 +1425,7 @@ void applyConfigRequest() {
   webDashboardEnabled = wifiEnabled && server.hasArg("web_dashboard_enabled");
   bootUpdateCheckEnabled = server.hasArg("boot_update_check");
   resumeEnabled = server.hasArg("resume_enabled");
+  resumePrecise = server.hasArg("resume_precise");   // checked = Precise cadence, else Balanced
   statsPingEnabled = server.hasArg("stats_ping");
   mqttEnabled = server.hasArg("mqtt_enabled");
   if (!wifiEnabled) mqttEnabled = false;
@@ -1575,6 +1578,7 @@ void resetWebConfigToDefaults() {
   webDashboardEnabled = true;
   bootUpdateCheckEnabled = true;
   resumeEnabled = true;
+  resumePrecise = false;
   saveDeviceConfig();
 }
 

--- a/src/Resume.ino
+++ b/src/Resume.ino
@@ -12,11 +12,18 @@
 //      written after every lower_print(). A loss during the long exposure
 //      lands here - the interrupted layer is re-exposed in full (slight
 //      over-cure of one layer, no geometry error).
-//   M  peel lift/lower in motion - pos is the height BEFORE the lift, the
-//      plate is physically somewhere in [pos, pos + lift]. Resume assumes the
-//      LOWEST height so a position error can only open a gap upward, never
-//      drive the print into the FEP.
+//   M  peel lift/lower in motion. `pos` is the exact cycle BASE (the layer's
+//      pre-lift height) - the recovery target is always pos+layerSteps, so it
+//      cannot drift. `live` (0.17 1-38b) is the plate's real height, written
+//      granularly during the move; resume relabels the physical plate as `live`
+//      then targets pos+layerSteps. The callers keep live <= true physical
+//      (actual while rising, down-biased while descending), so a position error
+//      can only open a gap UPWARD, never drive the print into the FEP.
 //   P  paused, plate parked at pos (exact).
+//
+// `live` defaults to `pos` for every legacy/stationary record (S/E/P and the
+// pre-0.17 M sites), so their behaviour is unchanged; only the in-motion granular
+// M records carry a distinct live.
 //
 // The record is fixed-width (padded numbers, folder last) so the in-place
 // rewrite covers the previous one exactly - no truncation needed, one sector.
@@ -27,10 +34,15 @@
 
 static const char *RESUME_PATH = "/tinymaker-resume.txt";
 
-// Write a checkpoint with an explicit position (steps from the print's home).
-void resumeCheckpointAt(char phase, long posSteps) {
+// Write one checkpoint record. `pos` is the exact cycle-BASE height used to
+// recompute the recovery target (drift-free); `live` is the plate's actual
+// height at write time, used ONLY to relabel the physical position on resume
+// (resumeRecoverPosition). Legacy callers pass live==pos, so their behaviour is
+// byte-identical to pre-0.17. Fixed-width, single-sector in-place rewrite:
+// folder stays last, so the record length is constant within one print.
+static void resumeWriteRecord(char phase, long posSteps, long liveSteps) {
   if (!resumeEnabled) return;   // 0-34: power-loss resume turned off -> never write a checkpoint
-  char buf[240];
+  char buf[256];
   uint32_t elapsedSecs = (millis() - printStartMs) / 1000UL;
   snprintf(buf, sizeof(buf),
            "TMR1\n"
@@ -39,13 +51,14 @@ void resumeCheckpointAt(char phase, long posSteps) {
            "total=%05d\n"
            "lh=%03d\n"
            "pos=%+011ld\n"
+           "live=%+011ld\n"
            "resin=%011.3f\n"
            "elapsed=%010lu\n"
            "uvled=%010lu\n"
            "folder=%s\n",
            phase, current_layer, layer_counter,
            (int)lroundf(Layer_Height * 100),
-           posSteps, resinUsedMl,
+           posSteps, liveSteps, resinUsedMl,
            (unsigned long)elapsedSecs,
            (unsigned long)(uvLedSessionMs / 1000UL),
            foldersel_long);
@@ -54,6 +67,22 @@ void resumeCheckpointAt(char phase, long posSteps) {
   f.seekSet(0);          // FILE_WRITE opens at end - rewrite from the start
   f.print(buf);
   f.close();
+}
+
+// Legacy checkpoint: exact stationary position (live == pos, so recovery
+// relabels to the very value it targets - the pre-0.17 behaviour).
+void resumeCheckpointAt(char phase, long posSteps) {
+  resumeWriteRecord(phase, posSteps, posSteps);
+}
+
+// Granular in-motion checkpoint (0.17 1-38b): `pos` = the exact cycle base
+// (drift-free target reference), `live` = the plate's real height right now.
+// Called from lift_print()/lower_print() so a power loss mid-motion recovers to
+// sub-mm instead of the pessimistic pre-lift low. `live` must satisfy the safety
+// invariant live <= true physical height for the whole window it is active (the
+// callers guarantee this: actual while rising, down-biased while descending).
+void resumeCheckpointLive(char phase, long posSteps, long liveSteps) {
+  resumeWriteRecord(phase, posSteps, liveSteps);
 }
 
 void resumeCheckpoint(char phase) {
@@ -114,11 +143,14 @@ bool resumeLoad() {
   long total = resumeNum(j, "total", -1);
   long lh = resumeNum(j, "lh", -1);
   long pos = resumeNum(j, "pos", -1);
+  long live = resumeNum(j, "live", pos);   // 0.17: absent in pre-0.17 records -> defaults to pos
   if (total < 1 || total > MAX_LAYER_FILES) return false;
   if (layer < 0 || layer >= total) return false;
   if (ph == 'S' && layer != 0) return false;
   if (lh != lroundf(Layer_Height * 100)) return false;   // setting changed
   if (pos < 0 || pos > (long)(max_height * steps_mm)) return false;
+  if (live < 0) live = 0;                                    // relabel-only value; keep in range
+  else if (live > (long)(max_height * steps_mm)) live = pos; // implausible -> fall back to exact base
 
   int p = j.indexOf("folder=");
   if (p < 0) return false;
@@ -147,6 +179,7 @@ bool resumeLoad() {
   resumeLayer = (int)layer;
   resumeTotal = (int)total;
   resumePosSteps = pos;
+  resumeLiveSteps = live;   // 0.17: physical relabel height (== pos for legacy records)
   resumeResinMl = resumeDbl(j, "resin", 0);
   resumeElapsedSecs = (uint32_t)resumeNum(j, "elapsed", 0);
   resumeUvLedSecs = (uint32_t)resumeNum(j, "uvled", 0);
@@ -225,8 +258,11 @@ void resumeRaisePlateAndDiscard() {
  * Re-establish Z after a power loss WITHOUT homing (the print would hit the
  * vat before the endstop). Trusts the checkpointed position, peels the last
  * (possibly half-cured, FEP-stuck) layer free, and settles the plate at the
- * next layer's exposure height. For 'M' the recorded pre-lift height is the
- * safe LOW assumption - a real position above it only shifts the print up.
+ * next layer's exposure height. The plate is relabelled as `resumeLiveSteps`
+ * (the checkpointed physical height; == the exact base for legacy records, or
+ * the granular in-motion height for 0.17 M records), which is always <= the true
+ * height - so the settle can only shift the print UP, never into the FEP. The
+ * TARGET is computed from the exact base `resumePosSteps` (drift-free).
  */
 void resumeRecoverPosition() {
   long liftSteps = (long)((Slow_Lift_Distance + Fast_Lift_Distance) * steps_mm);
@@ -239,7 +275,7 @@ void resumeRecoverPosition() {
   if (lowPos < 0) lowPos = 0;
   resumeCheckpointAt('M', lowPos);
 
-  stepper.setCurrentPosition(resumePosSteps);
+  stepper.setCurrentPosition(resumeLiveSteps);   // relabel to the real height (<= true; legacy == pos)
   stepper.enableOutputs();
 
   long target;

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -157,6 +157,14 @@ bool wifiEnabled = true;
 bool webDashboardEnabled = true;
 bool bootUpdateCheckEnabled = true;
 bool resumeEnabled = true;          // 0-34: false = never checkpoint / never offer power-loss resume
+bool resumePrecise = false;         // 0.17 1-38b: false = Balanced cadence, true = Precise (finer resume, more SD writes)
+long resumeLiveSteps = 0;           // 0.17: physical relabel height loaded from a checkpoint (== base for legacy records)
+long resumeCycleBaseSteps = 0;      // 0.17: exact pre-lift base of the current layer cycle (drift-free target reference)
+// Granular-checkpoint cadence during the ~9s lift/drop motion (0.17 1-38b).
+// Defined here (the first-concatenated TU) so Motor.ino - concatenated before
+// Resume.ino - can see them.
+#define RESUME_CKPT_MS_BALANCED 800
+#define RESUME_CKPT_MS_PRECISE  400
 String bootAnimName = "";      // "" = built-in splash; else a basename in /bootanim/
 bool wifiTemporarilyEnabled = false;
 bool webDashboardTemporarilyEnabled = false;
@@ -228,6 +236,7 @@ void loadDeviceConfig() {
   webDashboardEnabled = sysPrefs.getBool("webDash", true);
   bootUpdateCheckEnabled = sysPrefs.getBool("bootUpdChk", true);
   resumeEnabled = sysPrefs.getBool("resumeEn", true);
+  resumePrecise = sysPrefs.getBool("resumePrec", false);
   statsPingEnabled = sysPrefs.getBool("statsPing", true);
   prevRegularExposure = sysPrefs.getUChar("prevRegExp", 0);
   bootAnimName = sysPrefs.getString("bootAnimName", "");
@@ -276,6 +285,7 @@ void saveDeviceConfig() {
   sysPrefs.putBool("webDash", webDashboardEnabled);
   sysPrefs.putBool("bootUpdChk", bootUpdateCheckEnabled);
   sysPrefs.putBool("resumeEn", resumeEnabled);
+  sysPrefs.putBool("resumePrec", resumePrecise);
   sysPrefs.putBool("statsPing", statsPingEnabled);
   sysPrefs.putString("bootAnimName", bootAnimName);
   sysPrefs.putBool("mqttEnabled", mqttEnabled);
@@ -657,6 +667,8 @@ String buildConfigBackupJson(bool includeSecrets = true) {
   out += bootUpdateCheckEnabled ? "true" : "false";
   out += ",\"resumeEnabled\":";
   out += resumeEnabled ? "true" : "false";
+  out += ",\"resumePrecise\":";
+  out += resumePrecise ? "true" : "false";
   out += ",\"bootAnim\":\"";
   out += backupEscape(bootAnimName);
   out += "\"";
@@ -791,6 +803,7 @@ void applyConfigBackup(const String &j) {
   webDashboardEnabled = wifiEnabled && backupBool(j, "webDashboardEnabled", webDashboardEnabled);
   bootUpdateCheckEnabled = backupBool(j, "bootUpdateCheck", bootUpdateCheckEnabled);
   resumeEnabled = backupBool(j, "resumeEnabled", resumeEnabled);
+  resumePrecise = backupBool(j, "resumePrecise", resumePrecise);
   bootAnimName = backupStr(j, "bootAnim", bootAnimName);
   mqttEnabled = wifiEnabled && backupBool(j, "mqttEnabled", mqttEnabled);
   mqttHost = backupStr(j, "mqttHost", mqttHost);
@@ -1986,9 +1999,13 @@ void loop() {
             current_state = 2;
             screen1111_state();
           }
-          // Layer cured, peel begins: from here until the next 'E' the plate
-          // is somewhere in [pos, pos + lift] - resume assumes the low end.
-          if (!print_canceled) resumeCheckpoint('M');
+          // Layer cured, peel begins. 0.17 1-38b: capture the exact cycle base
+          // (this layer's pre-lift height) once; lift_print()/lower_print() then
+          // write granular 'M' checkpoints during the ~9s motion (first one on
+          // entry, replacing the old single pre-lift 'M'). `pos` = this base
+          // everywhere in the cycle (drift-free target); `live` tracks the real
+          // height so a mid-motion loss recovers sub-mm instead of to the low end.
+          if (!print_canceled) resumeCycleBaseSteps = stepper.currentPosition();
           // The service window moved from after the move to before it: a
           // pending status poll now answers "Lifting" with the countdown
           // ahead of it, not after the phase already ended. The measured

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -197,6 +197,7 @@
     <label class='check'><input name='low_resin_pause' id='cfgLowResinPause' type='checkbox' value='1'><span>Low resin pause (mid-print)</span></label>
     <label class='check'><input name='ask_refill' id='cfgAskRefill' type='checkbox' value='1'><span>Ask refill before print</span></label>
     <label class='check'><input name='resume_enabled' id='cfgResumeEnabled' type='checkbox' value='1'><span>Resume after power loss</span></label>
+    <label class='check'><input name='resume_precise' id='cfgResumePrecise' type='checkbox' value='1'><span>Precise resume checkpoints (finer recovery, more SD writes)</span></label>
     <label class='check'><input name='dry_run' id='cfgDryRun' type='checkbox' value='1'><span>Dry run mode</span></label>
   </div>
   <button type='submit'>Save config</button>
@@ -1943,7 +1944,7 @@ const loadConfig=async()=>{
     show('undoRegExp',prevR>0&&prevR!==Number(c.regularExposure));
     $('undoRegExp').textContent='Undo ('+prevR+'s)';
     $('undoRegExp').dataset.v=prevR;
-    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgVatMl').value=c.vatMl; $('cfgLowResinMl').value=c.lowResinMl; $('cfgLowResinPause').checked=!!c.lowResinPause; $('cfgAskRefill').checked=!!c.askRefill; $('cfgResumeEnabled').checked=!!c.resumeEnabled; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun; $('cfgWifiEnabled').checked=!!c.wifiEnabled; $('cfgWebDashboardEnabled').checked=!!c.webDashboardEnabled; $('cfgBootUpdateCheck').checked=!!c.bootUpdateCheck; $('cfgStatsPing').checked=!!c.statsPing;
+    $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgVatMl').value=c.vatMl; $('cfgLowResinMl').value=c.lowResinMl; $('cfgLowResinPause').checked=!!c.lowResinPause; $('cfgAskRefill').checked=!!c.askRefill; $('cfgResumeEnabled').checked=!!c.resumeEnabled; $('cfgResumePrecise').checked=!!c.resumePrecise; $('cfgUiTimeout').value=c.uiTimeoutSecs; $('cfgDryRun').checked=!!c.dryRun; $('cfgWifiEnabled').checked=!!c.wifiEnabled; $('cfgWebDashboardEnabled').checked=!!c.webDashboardEnabled; $('cfgBootUpdateCheck').checked=!!c.bootUpdateCheck; $('cfgStatsPing').checked=!!c.statsPing;
     $('cfgMqttEnabled').checked=!!c.mqttEnabled; $('cfgMqttHost').value=c.mqttHost||''; $('cfgMqttPort').value=c.mqttPort||1883; $('cfgMqttUser').value=c.mqttUser||''; $('cfgMqttPassword').value=''; $('cfgMqttTopic').value=c.mqttTopic||'TinyMaker';
     $('mqttHint').textContent=c.mqttPasswordSet?'Password is saved. Enter a new one only if you want to replace it.':'MQTT password is not set.';
     $('cfgConnectEnabled').checked=!!c.connectEnabled; $('cfgConnectBaseUrl').value=c.connectBaseUrl||'https://connect.tinymakerwifi.com'; $('cfgConnectPrinterName').value=c.connectPrinterName||''; $('cfgConnectLeaderboard').checked=!!c.connectLeaderboardOptIn;


### PR DESCRIPTION
Power-loss resume precision during the ~9 s lift/drop motion. Was: a single pre-lift 'M' (lowest assumption) → a loss mid-motion could resume up to the full lift distance (~3 mm) too HIGH (seam/rare delamination). Now: granular in-motion checkpoints.

## How
- New `live=` record field: `pos` stays the exact cycle base (drift-free recovery target), `live` is the real height used only to relabel the plate on resume. Legacy/stationary records set `live==pos` → byte-identical behaviour. Recovery change is one line (`setCurrentPosition(resumeLiveSteps)`); target math untouched.
- lift_print (live=actual, safe rising) + lower_print (live=currentPos−dropMargin, down-biased so live≤physical while descending; plate is frozen during any CPU stall). Drop write NOT gated on cancel (audit HIGH fix: a mid-drop cancel must keep refreshing live).
- Runtime toggle `resumePrecise` (Advanced→Resin "Resume mode", dashboard, NVS, backup): Balanced 800ms (~5–6× writes) / Precise 400ms (~11×). Ship both, A/B in real use, collapse to the winner later.

## Gate + hardware ✅
- Compiles (Flash 70.0%); firmware-auditor clean after the mid-drop-cancel HIGH fix.
- **Hardware (dry-run, build 958ca5f):** lift cut → resume L6, settled, continued; **drop cut (FEP-critical) → resume L11, no downward crush**, continued. Heap healthy throughout. (Balanced; Precise A/B next.)

Partial fix (~0.5 mm residual; true fix = hardware brownout cap). Reframing: precision at MORE SD writes, not a diet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)