### PR TITLE
Notify: power-restored push after a power-loss interruption (0.17 Sprint B, PR-notify)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ compile_commands.json
 # Generated from web/dashboard.html by scripts/gen_dashboard_gz.py (pre-build)
 src/dashboard_html_gz.h
 
+# Arduino preprocessor artifact (transient during `pio run`); must never be
+# committed - a stray copy double-compiles the sketch TU and breaks the build.
+src/*.ino.cpp
+
 # Local, private Claude skills (kept out of the public repo; backup: secret gist)
 .claude/skills/
 

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -3236,6 +3236,14 @@ void network_setup() {
   }
   statsPingMaybe();
   crashPingMaybe();
+  // 0.17: a power loss interrupted a print -> one push so a user who is away
+  // knows to resume (screen prompt + dashboard Resume already exist locally).
+  // Blocking send, but we are at the idle boot resume prompt - safe, like the
+  // other notifications at their idle exit points.
+  if (powerRestoreNotifyPending) {
+    powerRestoreNotifyPending = false;                 // once per boot
+    if (WiFi.status() == WL_CONNECTED) tgNotifyPowerRestored();
+  }
   otaBootCheckMaybePrompt();
   if (screen == 424) return;
 }

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -93,6 +93,7 @@ uint32_t sdRev = 0;
 // print-start code in this (first) file can see them.
 bool resumeStartPrint = false;      // boot resume prompt accepted -> start path
 bool resumeBootPending = false;     // suppresses the boot-update prompt
+bool powerRestoreNotifyPending = false; // 0.17: send one "power restored" push once WiFi is up this boot
 bool networkStarted = false;        // network_setup ran (it is idempotent via this)
 // 0-33: the dashboard's answer to the boot resume prompt - set by the
 // /api/resume/* handlers, consumed in loop() while screen 427 is up.
@@ -410,6 +411,7 @@ void screen422();   // "install from file" screen (Interface.ino, #if-guarded)
 void tgNotifyFinished();   // Telegram hooks (TinyMakerTelegram.ino, #if-guarded)
 void tgNotifyLowResin();
 void tgNotifyCanceled();
+void tgNotifyPowerRestored();   // 0.17: power-loss interrupted a print
 void screenBootUpdatePrompt();
 void screenBootUpdateDisablePrompt();
 #endif
@@ -1199,7 +1201,7 @@ void setup() {
   // interrupted print and answer it remotely; resumeBootPending suppresses
   // the boot-update prompt so nothing competes with the resume question.
   bool resumePendingBoot = resumeLoad();
-  if (resumePendingBoot) resumeBootPending = true;
+  if (resumePendingBoot) { resumeBootPending = true; powerRestoreNotifyPending = true; }  // 0.17: notify once WiFi is up
   #if ENABLE_NETWORK
   network_setup(); // SLIBBINAS WiFi + upload server (Network.ino)
   if (!resumePendingBoot && (screen == 424 || screen == 425)) return;

--- a/src/TinyMakerTelegram.ino
+++ b/src/TinyMakerTelegram.ino
@@ -104,6 +104,19 @@ void tgNotifyCanceled() {
   telegramNotify(msg);
 }
 
+// 0.17: power came back and a print was interrupted mid-run. Sent once per boot
+// from network_setup() after WiFi is up (resumeLayer/Total/Folder were filled by
+// resumeLoad() at boot). Lets a user who is away know to resume (screen prompt +
+// dashboard Resume). Same opt-in channel as the other notifications.
+void tgNotifyPowerRestored() {
+  if (!tgEnabled && !waEnabled && !dcEnabled) return;
+  String msg = "Power restored - print interrupted at layer " +
+               String(resumeLayer) + "/" + String(resumeTotal);
+  if (resumeFolder[0]) msg += " (" + String(resumeFolder) + ")";
+  msg += ". Resume from the dashboard or the printer.";
+  telegramNotify(msg);
+}
+
 // Appended to configJson(). The token itself is never sent to the browser.
 String tinymakerTelegramConfigJson() {
   String out = ",\"tgEnabled\":";


### PR DESCRIPTION
A 4th notification (after finished/low-resin/canceled): "Power restored - print interrupted at layer X/Y (model). Resume from the dashboard or the printer." Power-loss resume previously had no phone notification — only the on-screen prompt + dashboard resumePending, so a user who was away didn't know a print was waiting to resume.

## How
- Sent ONCE per boot from network_setup() after WiFi is up (next to crashPingMaybe), guarded by WL_CONNECTED and an enabled channel; uses the resumeLayer/Total/Folder resumeLoad() already filled at boot.
- Same opt-in router (telegramNotify → Telegram/WhatsApp/Discord). No send when power-loss resume is off. Blocking TLS but at the idle boot resume prompt, like the other sends at their idle exits. Pairs with remote resume (0-33): push → tap Resume in the dashboard.
- Also gitignore src/*.ino.cpp (transient Arduino-preprocessor artifact the auditor flagged).

## Gate + hardware ✅
- Compiles (Flash 70.0%); firmware-auditor clean (no HIGH/MED).
- **Hardware (dry-run, 958ca5f):** power cut mid-print → reboot → **Telegram push arrived** ("Power restored - layer 6/154 (Tooth)"), verified alongside the resume-granular power-cut tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)