### PR TITLE
0.17: decisecond exposure (0-3) + exp-test display fix

### DIFF
--- a/src/Import.ino
+++ b/src/Import.ino
@@ -117,7 +117,7 @@ bool modelSummaryFromSourceLayers(int sourceLayers, ModelSummary &summary) {
   long movementLayers = summary.printLayers - 1;
   if (movementLayers < 0) movementLayers = 0;
   summary.estimatedSecs = (Base_Layer * Base_Exposure) +
-                          (exposureLayers * Regular_Exposure) +
+                          (exposureLayers * Regular_Exposure / 10) +   // 0.17 0-3: ds -> s
                           (uint32_t)(motor_updown_time * movementLayers);
   return true;
 }

--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -3257,7 +3257,7 @@ void screen3111decrease(){
       }
         break;
       case 2:
-      if(Base_Exposure > 10){
+      if(Base_Exposure > 5){   // 0.17 0-3: base min 5 s (fast resins)
         Base_Exposure --;
         gfx2->fillRect(3, 20, 80, 17, BLACK);
         gfx2->setCursor(5, 33);
@@ -3358,7 +3358,7 @@ void screen3111decrease(){
   if (setting_item_updown == 0) {
     switch (setting_item){
       case 2:
-      if(Base_Exposure > 10){
+      if(Base_Exposure > 5){   // 0.17 0-3: base min 5 s (fast resins)
         Base_Exposure --;
         gfx2->fillRect(3, 61, 80, 17, BLACK);
         gfx2->setCursor(5, 74);

--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -670,7 +670,7 @@ String advancedValue(int item) {
   if (item == 6) return askRefillEnabled ? "On" : "Off";
   if (item == 7) return wifiEnabled ? "On" : "Off";
   if (item == 8) return bootUpdateCheckEnabled ? "On" : "Off";
-  if (item == 9) return String(expTestBarSecs(1)) + "-" + String(expTestBarSecs(8)) + "s strip";
+  if (item == 9) return String(expTestBarSecs(1) / 10.0, 1) + "-" + String(expTestBarSecs(8) / 10.0, 1) + "s";   // 0.17 0-3: ds -> X.X s
   if (item == 10) {
     if (bootAnimName.length() == 0) return "Default";
     if (bootAnimShuffleSelected(bootAnimName)) return "Shuffle";
@@ -2419,7 +2419,7 @@ void screenExpTestIntro(){
   // string on these screens is measured to fit FreeSans8pt7b at its widest value.
   gfx2->print("Resin in vat, no plate");
   gfx2->setCursor(8, 48);
-  gfx2->print(String("Cures 8 bars: ") + String(expTestBarSecs(1) / 10.0, 1) + "-" + String(expTestBarSecs(8) / 10.0, 1) + "s");
+  gfx2->print(String("8 bars: ") + String(expTestBarSecs(1) / 10.0, 1) + "-" + String(expTestBarSecs(8) / 10.0, 1) + "s");   // shortened: ds strings are wider
   uiButtons("Back", "Start", 0x879F);
   screen = 232;
 }
@@ -2490,7 +2490,7 @@ void runExpTest(){
   if (!canceled){
     gfx2->setTextColor(0x879F);
     gfx2->setCursor(8, 34);
-    gfx2->print(String("Dots 1..8 = ") + String(expTestBarSecs(1) / 10.0, 1) + ".." + String(expTestBarSecs(8) / 10.0, 1) + "s");
+    gfx2->print(String("Dots 1-8: ") + String(expTestBarSecs(1) / 10.0, 1) + "-" + String(expTestBarSecs(8) / 10.0, 1) + "s");   // shortened
     gfx2->setCursor(8, 48);
     gfx2->print("Rinse, then pick bar");
     uiButtons("Skip", "Pick", 0x879F);

--- a/src/Interface.ino
+++ b/src/Interface.ino
@@ -1342,7 +1342,7 @@ void screen111(){
 
   // Calculate print time
   estimated_seconds += Base_Layer * Base_Exposure;
-  estimated_seconds += (layer_counter - Base_Layer) * Regular_Exposure;
+  estimated_seconds += (layer_counter - Base_Layer) * Regular_Exposure / 10;   // 0.17 0-3: ds -> s
   motor_updown_time_total = motor_updown_time * (layer_counter - 1);
   estimated_seconds += motor_updown_time_total; 
   estimated_hours = estimated_seconds / 3600;
@@ -2389,21 +2389,18 @@ void screen23111(){
 // bar 5 = 100% = your current value. A fast resin (cures in 3 s) and a slow
 // one (25 s) both get a meaningful spread - fixed +-seconds steps did not
 // (first real strip saturated: every bar past ~8 s looked identical).
-// Whole seconds cannot hold a +-60% spread once Regular drops low: at 1 s the
-// percentages all rounded to the same value and the strip burned eight
-// identical bars that blanked at once (user finding, 0.15.0 testing). Exposure
-// is settable only in whole seconds (one EEPROM byte, 1..30), so a sub-second
-// ladder would produce bars nobody can then set. Below ~5 s the ladder
-// therefore stops being proportional and becomes a 1 s sweep - every bar stays
-// distinct and every bar maps to a value the pick can actually apply. From ~6 s
-// up the percentages already separate on their own and nothing changes here.
-int expTestBarSecs(int bar) {          // bar 1..8 -> seconds, always distinct
+// 0.17 0-3: Regular exposure is now DECISECONDS, so the ladder stays truly
+// proportional (+-60%) even at low exposure - the old "below ~5 s fall back to a
+// 1 s sweep" hack (whole-second EEPROM byte) is gone. Bars are floored at 1.0 s
+// and forced distinct by at least 0.1 s. Returns DECISECONDS (the "Secs" name is
+// kept only because it has many callers).
+int expTestBarSecs(int bar) {          // bar 1..8 -> deciseconds, always distinct
   static const uint8_t pct[8] = {40, 55, 70, 85, 100, 115, 135, 160};
   int t[8];
   for (int i = 0; i < 8; i++) {
-    t[i] = ((int)Regular_Exposure * pct[i] + 50) / 100;
-    if (t[i] < 1) t[i] = 1;                          // 1 s = the settable floor
-    if (i && t[i] <= t[i - 1]) t[i] = t[i - 1] + 1;
+    t[i] = ((int)Regular_Exposure * pct[i] + 50) / 100;   // Regular is ds -> t is ds
+    if (t[i] < 10) t[i] = 10;                             // 1.0 s = the settable floor
+    if (i && t[i] <= t[i - 1]) t[i] = t[i - 1] + 1;       // distinct by >= 0.1 s
   }
   return t[bar - 1];
 }
@@ -2422,7 +2419,7 @@ void screenExpTestIntro(){
   // string on these screens is measured to fit FreeSans8pt7b at its widest value.
   gfx2->print("Resin in vat, no plate");
   gfx2->setCursor(8, 48);
-  gfx2->print(String("Cures 8 bars: ") + expTestBarSecs(1) + "-" + expTestBarSecs(8) + "s");
+  gfx2->print(String("Cures 8 bars: ") + String(expTestBarSecs(1) / 10.0, 1) + "-" + String(expTestBarSecs(8) / 10.0, 1) + "s");
   uiButtons("Back", "Start", 0x879F);
   screen = 232;
 }
@@ -2459,7 +2456,7 @@ void runExpTest(){
       gfx1->fillCircle(x0 + bw / 2, by + 3 * r + k * 3 * r, r, BLACK);
   }
 
-  long maxMs = (long)expTestBarSecs(8) * 1000L;
+  long maxMs = (long)expTestBarSecs(8) * 100L;   // 0.17 0-3: bars are deciseconds -> ms
   int blanked = 0;
   bool canceled = false;
   digitalWrite(FAN, HIGH);
@@ -2468,7 +2465,7 @@ void runExpTest(){
   Duration = 0;
   while (Duration <= maxMs && !canceled){
     Duration = millis() - startTime;
-    while (blanked < 8 && Duration >= (long)expTestBarSecs(blanked + 1) * 1000L){
+    while (blanked < 8 && Duration >= (long)expTestBarSecs(blanked + 1) * 100L){   // ds -> ms
       gfx1->fillRect(blanked * slot + gap, by, bw, bh, BLACK);
       blanked++;
     }
@@ -2493,7 +2490,7 @@ void runExpTest(){
   if (!canceled){
     gfx2->setTextColor(0x879F);
     gfx2->setCursor(8, 34);
-    gfx2->print(String("Dots 1..8 = ") + expTestBarSecs(1) + ".." + expTestBarSecs(8) + "s");
+    gfx2->print(String("Dots 1..8 = ") + String(expTestBarSecs(1) / 10.0, 1) + ".." + String(expTestBarSecs(8) / 10.0, 1) + "s");
     gfx2->setCursor(8, 48);
     gfx2->print("Rinse, then pick bar");
     uiButtons("Skip", "Pick", 0x879F);
@@ -2524,12 +2521,12 @@ void screenExpTestPick(){
   gfx2->setTextColor(0x879F);
   gfx2->setCursor(8, 38);
   if (expTestPick <= 8) {
-    gfx2->print(String(expTestPick) + " dots -> " + expTestBarSecs(expTestPick) + "s");
+    gfx2->print(String(expTestPick) + " dots -> " + String(expTestBarSecs(expTestPick) / 10.0, 1) + "s");
     if (expTestBarSecs(expTestPick) == (int)Regular_Exposure) gfx2->print(" (now)");
   } else if (expTestPick == 9) {
-    gfx2->print(String("All fat -> ") + expTestBarSecs(1) + "s");
+    gfx2->print(String("All fat -> ") + String(expTestBarSecs(1) / 10.0, 1) + "s");
   } else {
-    gfx2->print(String("All soft -> ") + expTestBarSecs(8) + "s");
+    gfx2->print(String("All soft -> ") + String(expTestBarSecs(8) / 10.0, 1) + "s");
   }
   gfx2->setCursor(8, 52);
   gfx2->print(expTestPick <= 8 ? "UP = next" : "UP = next (retest)");
@@ -2539,9 +2536,9 @@ void screenExpTestPick(){
 }
 
 void expTestApplyPick(){
-  int t = expTestBarSecs(expTestPick <= 8 ? expTestPick : (expTestPick == 9 ? 1 : 8));
-  if (t < 1) t = 1;
-  if (t > 30) t = 30;
+  int t = expTestBarSecs(expTestPick <= 8 ? expTestPick : (expTestPick == 9 ? 1 : 8));  // deciseconds
+  if (t < 10) t = 10;    // 0.17 0-3: ds range (1.0 s)
+  if (t > 300) t = 300;  // (30.0 s)
   long oldR = Regular_Exposure;
   Regular_Exposure = t;
   savePrintSettings();
@@ -2606,7 +2603,7 @@ void screen31UP(){
       gfx2->setCursor(5, 56);
       gfx2->println("Regular Exposure");
       gfx2->setCursor(5, 74);
-      gfx2->print(Regular_Exposure);
+      gfx2->print(Regular_Exposure / 10.0, 1);
       gfx2->print(" "); 
       gfx2->print("s");      
       gfx2->drawRoundRect(0, 41, 160, 39, 3, BLACK);
@@ -2616,7 +2613,7 @@ void screen31UP(){
       gfx2->setCursor(5, 15);
       gfx2->println("Regular Exposure"); 
       gfx2->setCursor(5, 33);
-      gfx2->print(Regular_Exposure); 
+      gfx2->print(Regular_Exposure / 10.0, 1); 
       gfx2->print(" "); 
       gfx2->print("s");  
       gfx2->setCursor(5, 56);
@@ -2814,7 +2811,7 @@ void screen31DOWN(){
       gfx2->setCursor(5, 56);
       gfx2->println("Regular Exposure");
       gfx2->setCursor(5, 74);
-      gfx2->print(Regular_Exposure);
+      gfx2->print(Regular_Exposure / 10.0, 1);
       gfx2->print(" "); 
       gfx2->print("s");       
       gfx2->drawRoundRect(0, 41, 160, 39, 3, WHITE);
@@ -2824,7 +2821,7 @@ void screen31DOWN(){
       gfx2->setCursor(5, 15);
       gfx2->println("Regular Exposure"); 
       gfx2->setCursor(5, 33);
-      gfx2->print(Regular_Exposure); 
+      gfx2->print(Regular_Exposure / 10.0, 1); 
       gfx2->print(" "); 
       gfx2->print("s"); 
       gfx2->setCursor(5, 56);
@@ -3043,11 +3040,11 @@ void screen3111increase(){
       }
         break;
       case 3:
-      if(Regular_Exposure < 30){
+      if(Regular_Exposure < 300){   // 0.17 0-3: deciseconds (max 30.0 s), +1 ds = +0.1 s/press
         Regular_Exposure ++;
         gfx2->fillRect(3, 20, 80, 17, BLACK);
         gfx2->setCursor(5, 33);
-        gfx2->print(Regular_Exposure);
+        gfx2->print(Regular_Exposure / 10.0, 1);
         gfx2->print(" "); 
         gfx2->print("s");
       }
@@ -3144,11 +3141,11 @@ void screen3111increase(){
       }
         break; 
       case 3:
-      if(Regular_Exposure < 30){
+      if(Regular_Exposure < 300){   // 0.17 0-3: deciseconds (max 30.0 s), +1 ds = +0.1 s/press
         Regular_Exposure ++;
         gfx2->fillRect(3, 61, 80, 17, BLACK);
         gfx2->setCursor(5, 74);
-        gfx2->print(Regular_Exposure);
+        gfx2->print(Regular_Exposure / 10.0, 1);
         gfx2->print(" "); 
         gfx2->print("s");
       }
@@ -3270,11 +3267,11 @@ void screen3111decrease(){
       }
         break;
       case 3:
-      if(Regular_Exposure > 1){
+      if(Regular_Exposure > 10){   // 0.17 0-3: deciseconds (min 1.0 s), -1 ds = -0.1 s/press
         Regular_Exposure --;
         gfx2->fillRect(3, 20, 80, 17, BLACK);
         gfx2->setCursor(5, 33);
-        gfx2->print(Regular_Exposure);
+        gfx2->print(Regular_Exposure / 10.0, 1);
         gfx2->print(" "); 
         gfx2->print("s");
       }
@@ -3371,11 +3368,11 @@ void screen3111decrease(){
       }
         break;
       case 3:
-      if(Regular_Exposure > 1){
+      if(Regular_Exposure > 10){   // 0.17 0-3: deciseconds (min 1.0 s), -1 ds = -0.1 s/press
         Regular_Exposure --;
         gfx2->fillRect(3, 61, 80, 17, BLACK);
         gfx2->setCursor(5, 74);
-        gfx2->print(Regular_Exposure);
+        gfx2->print(Regular_Exposure / 10.0, 1);
         gfx2->print(" "); 
         gfx2->print("s");
       }

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -756,7 +756,7 @@ uint32_t remainingPrintSecs() {
   if (current_layer < Base_Layer) {
     secs += (Base_Layer - current_layer) * Base_Exposure;
   }
-  secs += layersLeft * Regular_Exposure;
+  secs += layersLeft * Regular_Exposure / 10;   // 0.17 0-3: ds -> s
   if (layersLeft > 1) {
     secs += (uint32_t)((layersLeft - 1) * motor_updown_time);
   }
@@ -1327,9 +1327,9 @@ String configJson() {
   out += ",\"baseExposure\":";
   out += String(Base_Exposure);
   out += ",\"regularExposure\":";
-  out += String(Regular_Exposure);
+  out += String(Regular_Exposure / 10.0, 1);      // 0.17 0-3: seconds (deciseconds/10)
   out += ",\"prevRegularExposure\":";
-  out += String(prevRegularExposure);
+  out += String(prevRegularExposure / 10.0, 1);   // seconds (0.0 = no undo available)
   out += ",\"baseLayers\":";
   out += String(Base_Layer);
   out += ",\"transitionLayers\":";
@@ -1406,7 +1406,15 @@ void applyConfigRequest() {
   Layer_Height = requestedLayer < 0.075 ? 0.05 : 0.10;
   Base_Exposure = formLong("base_exposure", Base_Exposure, 10, 60);
   long oldRegular = Regular_Exposure;
-  Regular_Exposure = formLong("regular_exposure", Regular_Exposure, 1, 30);
+  {
+    // 0.17 0-3: the form sends Regular in SECONDS (step 0.1); store deciseconds.
+    float regSecs = server.hasArg("regular_exposure")
+                      ? server.arg("regular_exposure").toFloat()
+                      : (Regular_Exposure / 10.0f);
+    long regDs = lroundf(regSecs * 10.0f);
+    if (regDs < 10) regDs = 10; else if (regDs > 300) regDs = 300;
+    Regular_Exposure = regDs;
+  }
   rememberPrevRegularExposure(oldRegular);   // no-op unless it actually changed
   Base_Layer = formLong("base_layer", Base_Layer, 1, 8);
   Transition_Layer = formLong("transition_layer", Transition_Layer, 0, 10);

--- a/src/Network.ino
+++ b/src/Network.ino
@@ -1404,7 +1404,7 @@ String configJson() {
 void applyConfigRequest() {
   float requestedLayer = server.hasArg("layer_height") ? server.arg("layer_height").toFloat() : Layer_Height;
   Layer_Height = requestedLayer < 0.075 ? 0.05 : 0.10;
-  Base_Exposure = formLong("base_exposure", Base_Exposure, 10, 60);
+  Base_Exposure = formLong("base_exposure", Base_Exposure, 5, 60);   // 0.17 0-3: base min 5 s
   long oldRegular = Regular_Exposure;
   {
     // 0.17 0-3: the form sends Regular in SECONDS (step 0.1); store deciseconds.

--- a/src/Resume.ino
+++ b/src/Resume.ino
@@ -191,11 +191,12 @@ bool resumeLoad() {
 // transition layer starting from Base_Exposure - replay the decrements for
 // the layers that were already cured before the power loss.
 float resumeTransitionExposureSeed(int curedLayers) {
-  if (curedLayers <= Base_Layer) return Base_Exposure;
+  // 0.17 0-3: ramp accumulator is in DECISECONDS (Base*10 down to Regular).
+  if (curedLayers <= Base_Layer) return Base_Exposure * 10;
   int done = curedLayers - Base_Layer;
   if (done > Transition_Layer) done = Transition_Layer;
-  float c = (float)(Base_Exposure - Regular_Exposure) / (float)(Transition_Layer + 1);
-  return (float)Base_Exposure - c * done;
+  float c = (float)(Base_Exposure * 10 - Regular_Exposure) / (float)(Transition_Layer + 1);
+  return (float)(Base_Exposure * 10) - c * done;
 }
 
 /**

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -803,7 +803,7 @@ static long backupClamp(double v, long lo, long hi) {
 // so a hand-edited or stale file can't smuggle absurd values in.
 void applyConfigBackup(const String &j) {
   Layer_Height = backupNum(j, "layerHeight", Layer_Height) < 0.075 ? 0.05 : 0.10;
-  Base_Exposure = backupClamp(backupNum(j, "baseExposure", Base_Exposure), 10, 60);
+  Base_Exposure = backupClamp(backupNum(j, "baseExposure", Base_Exposure), 5, 60);   // 0.17 0-3: base min 5 s
   // 0.17 0-3: backup stores Regular in SECONDS (downgrade-readable); convert to
   // deciseconds on restore, preserving 0.1 s (backupClamp->long would drop it).
   {
@@ -1205,7 +1205,7 @@ void setup() {
   // left by a firmware with a different EEPROM layout land exactly here. These
   // are the ranges the dashboard form, the backup restore and the LCD menu
   // already agree on.
-  if (Base_Exposure < 10 || Base_Exposure > 60) {
+  if (Base_Exposure < 5 || Base_Exposure > 60) {   // 0.17 0-3: min 5 s (was 10) for fast resins
     Base_Exposure = 35;
     EEPROM.write(2, (uint8_t)Base_Exposure);
     EEPROM.commit();

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -194,7 +194,7 @@ String waApiKey = "";               // CallMeBot key (secret - never echoed to b
 bool dcEnabled = false;             // Discord notifications via a channel webhook
 String dcWebhook = "";              // webhook URL (secret - never echoed to browser)
 bool statsPingEnabled = true;       // anonymous install ping (MAC hash + version + print hours)
-uint8_t prevRegularExposure = 0;    // last replaced Regular exposure (0 = none) - dashboard Undo
+uint16_t prevRegularExposure = 0;   // last replaced Regular exposure in DECISECONDS (0 = none) - dashboard Undo
 unsigned long lastUiActivityMs = 0;
 bool uiBlanked = false;
 uint8_t uiSaverPos = 0;               // 0-21 idle screen saver: which of the 5 spots
@@ -239,7 +239,7 @@ void loadDeviceConfig() {
   resumeEnabled = sysPrefs.getBool("resumeEn", true);
   resumePrecise = sysPrefs.getBool("resumePrec", false);
   statsPingEnabled = sysPrefs.getBool("statsPing", true);
-  prevRegularExposure = sysPrefs.getUChar("prevRegExp", 0);
+  prevRegularExposure = sysPrefs.getUShort("prevRegDs", 0);   // 0.17 0-3: deciseconds (new key; old UChar prevRegExp abandoned)
   bootAnimName = sysPrefs.getString("bootAnimName", "");
   mqttEnabled = sysPrefs.getBool("mqttEnabled", false);
   mqttHost = sysPrefs.getString("mqttHost", "");
@@ -540,8 +540,8 @@ int current_state = 0; // Current printing state
 
 // Print Parameters (Loaded from EEPROM) 
 float Layer_Height ;        // Layer thickness (mm)
-long Base_Exposure ;        // Exposure time for base layers (s)
-long Regular_Exposure ;     // Exposure time for normal layers (s)
+long Base_Exposure ;        // Exposure time for base layers (whole seconds)
+long Regular_Exposure ;     // Exposure for normal layers, in DECISECONDS (0.17 0-3; e.g. 140 = 14.0 s)
 byte Base_Layer ;           // Number of base layers
 byte Transition_Layer ;     // Number of transition layers
 byte Slow_Lift_Distance ;   // Distance for slow lift (mm)
@@ -571,10 +571,27 @@ String FileName;          // Current file name
 File myfile;
 PNG png; // PNG decoder instance
 
+// 0.17 0-3: EEPROM schema version lives in addr 0 (previously unused). v2 stores
+// Regular exposure as 2-byte DECISECONDS at addr 12-13; addr 3 still holds the
+// rounded whole-second value so a downgrade to <= 0.16 reads a sane number.
+#define SETTINGS_SCHEMA_VER 2
+#define EE_ADDR_SCHEMA 0
+#define EE_ADDR_REG_DS 12
+
+static uint16_t eepromReadU16(int addr) {
+  return (uint16_t)EEPROM.read(addr) | ((uint16_t)EEPROM.read(addr + 1) << 8);
+}
+static void eepromWriteU16(int addr, uint16_t v) {
+  EEPROM.write(addr, (uint8_t)(v & 0xFF));
+  EEPROM.write(addr + 1, (uint8_t)(v >> 8));
+}
+
 void savePrintSettings() {
+  EEPROM.write(EE_ADDR_SCHEMA, SETTINGS_SCHEMA_VER);
   EEPROM.write(1, Layer_Height * 100);
   EEPROM.write(2, Base_Exposure);
-  EEPROM.write(3, Regular_Exposure);
+  EEPROM.write(3, (uint8_t)lroundf(Regular_Exposure / 10.0f));   // downgrade-safe whole seconds
+  eepromWriteU16(EE_ADDR_REG_DS, (uint16_t)Regular_Exposure);    // canonical: deciseconds
   EEPROM.write(4, Base_Layer);
   EEPROM.write(5, Transition_Layer);
   EEPROM.write(6, Slow_Lift_Distance);
@@ -591,10 +608,10 @@ void savePrintSettings() {
 // the old value is remembered so the dashboard can offer a one-click Undo.
 // Undo goes through the same path, so undo-of-undo swaps back.
 void rememberPrevRegularExposure(long oldVal) {
-  if (oldVal <= 0 || oldVal > 30 || oldVal == Regular_Exposure) return;
-  prevRegularExposure = (uint8_t)oldVal;
+  if (oldVal <= 0 || oldVal > 300 || oldVal == Regular_Exposure) return;   // deciseconds now
+  prevRegularExposure = (uint16_t)oldVal;
   sysPrefs.begin("tinymaker", false);
-  sysPrefs.putUChar("prevRegExp", prevRegularExposure);
+  sysPrefs.putUShort("prevRegDs", prevRegularExposure);
   sysPrefs.end();
 }
 
@@ -634,7 +651,7 @@ String buildConfigBackupJson(bool includeSecrets = true) {
   out += ",\"baseExposure\":";
   out += String(Base_Exposure);
   out += ",\"regularExposure\":";
-  out += String(Regular_Exposure);
+  out += String(Regular_Exposure / 10.0, 1);   // 0.17 0-3: seconds (ds/10) - human-readable + downgrade-safe
   out += ",\"baseLayers\":";
   out += String(Base_Layer);
   out += ",\"transitionLayers\":";
@@ -787,7 +804,14 @@ static long backupClamp(double v, long lo, long hi) {
 void applyConfigBackup(const String &j) {
   Layer_Height = backupNum(j, "layerHeight", Layer_Height) < 0.075 ? 0.05 : 0.10;
   Base_Exposure = backupClamp(backupNum(j, "baseExposure", Base_Exposure), 10, 60);
-  Regular_Exposure = backupClamp(backupNum(j, "regularExposure", Regular_Exposure), 1, 30);
+  // 0.17 0-3: backup stores Regular in SECONDS (downgrade-readable); convert to
+  // deciseconds on restore, preserving 0.1 s (backupClamp->long would drop it).
+  {
+    double regSecs = backupNum(j, "regularExposure", Regular_Exposure / 10.0);
+    long regDs = lroundf((float)regSecs * 10.0f);
+    if (regDs < 10) regDs = 10; else if (regDs > 300) regDs = 300;
+    Regular_Exposure = regDs;
+  }
   Base_Layer = backupClamp(backupNum(j, "baseLayers", Base_Layer), 1, 8);
   Transition_Layer = backupClamp(backupNum(j, "transitionLayers", Transition_Layer), 0, 10);
   Slow_Lift_Distance = backupClamp(backupNum(j, "slowLiftDistance", Slow_Lift_Distance), 1, 3);
@@ -1040,9 +1064,11 @@ bool handleUiTimeout() {
  * Layer_Height is stored x100 (10 -> 0.10 mm).
  */
 void resetSettingsToDefault() {
+  EEPROM.write(EE_ADDR_SCHEMA, SETTINGS_SCHEMA_VER);
   EEPROM.write(1, 10);   // Layer_Height     -> 0.10 mm
   EEPROM.write(2, 35);   // Base_Exposure
-  EEPROM.write(3, 14);   // Regular_Exposure
+  EEPROM.write(3, 14);   // Regular_Exposure whole-second mirror (downgrade-safe)
+  eepromWriteU16(EE_ADDR_REG_DS, 140);  // Regular_Exposure = 14.0 s in deciseconds
   EEPROM.write(4, 2);    // Base_Layer
   EEPROM.write(5, 5);    // Transition_Layer
   EEPROM.write(6, 1);    // Slow_Lift_Distance
@@ -1055,7 +1081,7 @@ void resetSettingsToDefault() {
 
   Layer_Height = EEPROM.read(1) / 100.00;
   Base_Exposure = EEPROM.read(2);
-  Regular_Exposure = EEPROM.read(3);
+  Regular_Exposure = eepromReadU16(EE_ADDR_REG_DS);   // deciseconds
   Base_Layer = EEPROM.read(4);
   Transition_Layer = EEPROM.read(5);
   Slow_Lift_Distance = EEPROM.read(6);
@@ -1137,7 +1163,7 @@ void setup() {
   // Layer Height is stored multiplied by 100 to save as integer, so divide by 100.00 to restore float  
   Layer_Height = EEPROM.read(1) / 100.00;
   Base_Exposure = EEPROM.read(2);
-  Regular_Exposure = EEPROM.read(3);
+  // Regular_Exposure is loaded below (0.17 0-3 migration: deciseconds at addr 12-13).
   Base_Layer = EEPROM.read(4);
   Transition_Layer = EEPROM.read(5);
   Slow_Lift_Distance = EEPROM.read(6);
@@ -1155,6 +1181,22 @@ void setup() {
     settingsWereFactoryReset = true;   // a full reflash wiped the settings
   }
 
+  // 0.17 0-3: Regular exposure moved to 2-byte DECISECONDS (addr 12-13). A
+  // pre-0.17 install has schema (addr 0) != v2; migrate ONCE by scaling the old
+  // whole-second byte (addr 3) x10. resetSettingsToDefault() above already wrote
+  // schema=v2 + the ds value on a fresh flash, so that path takes the else here.
+  if (EEPROM.read(EE_ADDR_SCHEMA) != SETTINGS_SCHEMA_VER) {
+    uint8_t regS = EEPROM.read(3);
+    if (regS < 1 || regS > 30) regS = 14;   // sane-guard the old byte before scaling
+    Regular_Exposure = (long)regS * 10;
+    eepromWriteU16(EE_ADDR_REG_DS, (uint16_t)Regular_Exposure);
+    EEPROM.write(3, regS);                   // keep the whole-second downgrade mirror in sync
+    EEPROM.write(EE_ADDR_SCHEMA, SETTINGS_SCHEMA_VER);
+    EEPROM.commit();
+  } else {
+    Regular_Exposure = eepromReadU16(EE_ADDR_REG_DS);
+  }
+
   // Exposures are read raw, and the guard above only inspects Layer_Height, so
   // a bad byte here reached the print loop unchecked. Regular_Exposure = 0
   // makes turn_on_LED() compute 0 ms: the LED goes HIGH and LOW with no wait
@@ -1168,9 +1210,10 @@ void setup() {
     EEPROM.write(2, (uint8_t)Base_Exposure);
     EEPROM.commit();
   }
-  if (Regular_Exposure < 1 || Regular_Exposure > 30) {
-    Regular_Exposure = 14;
-    EEPROM.write(3, (uint8_t)Regular_Exposure);
+  if (Regular_Exposure < 10 || Regular_Exposure > 300) {   // deciseconds (1.0-30.0 s)
+    Regular_Exposure = 140;
+    eepromWriteU16(EE_ADDR_REG_DS, 140);
+    EEPROM.write(3, 14);   // keep the whole-second downgrade mirror in sync
     EEPROM.commit();
   }
 
@@ -1474,7 +1517,7 @@ void loop() {
       case 3111:
       Layer_Height = EEPROM.read(1) / 100.00;
       Base_Exposure = EEPROM.read(2);
-      Regular_Exposure = EEPROM.read(3);
+      Regular_Exposure = eepromReadU16(EE_ADDR_REG_DS);   // 0.17 0-3: deciseconds (revert to saved)
       Base_Layer = EEPROM.read(4);
       Transition_Layer = EEPROM.read(5);
       Slow_Lift_Distance = EEPROM.read(6);
@@ -1746,7 +1789,7 @@ void loop() {
         current_state = 0;
         current_layer = 0;
         Position_before_pause = 0;
-        Transition_Exposure = Base_Exposure;
+        Transition_Exposure = Base_Exposure * 10;   // 0.17 0-3: ramp accumulator in deciseconds
         #if ENABLE_NETWORK
         // 0-19: snapshot the model preview into RAM while the SD is still
         // free - once the print loop owns the bus, browsers get this copy.
@@ -1934,7 +1977,7 @@ void loop() {
           motor_updown_time_total = 0;
           if (current_layer < Base_Layer)
             estimated_seconds += (Base_Layer - current_layer) * Base_Exposure;                
-          estimated_seconds += (layer_counter - current_layer) * Regular_Exposure;            
+          estimated_seconds += (layer_counter - current_layer) * Regular_Exposure / 10;   // 0.17 0-3: ds -> s            
           motor_updown_time_total += (layer_counter - current_layer - 1) * motor_updown_time;            
           estimated_seconds += motor_updown_time_total;             
           estimated_hours = estimated_seconds / 3600;

--- a/src/UVLED.ino
+++ b/src/UVLED.ino
@@ -18,16 +18,18 @@ static void uvOffTimerCb(void *) { digitalWrite(LED, LOW); }
 void turn_on_LED(){
   long ExposureMillis;
   if(current_layer <= Base_Layer)
-    ExposureMillis = Base_Exposure * 1000;
+    ExposureMillis = Base_Exposure * 1000;   // base layers: whole seconds -> ms
   if(current_layer > Base_Layer && current_layer <= Base_Layer + Transition_Layer){
-    int a = Base_Exposure - Regular_Exposure;
+    // 0.17 0-3: ramp in DECISECONDS from Base (x10) down to Regular (already ds).
+    // Transition_Exposure is seeded to Base_Exposure*10 at print start / resume.
+    float a = (float)(Base_Exposure * 10 - Regular_Exposure);
     int b = Transition_Layer + 1;
-    float c = (float)a / (float)b;
+    float c = a / (float)b;
     Transition_Exposure -= c;
-    ExposureMillis = Transition_Exposure * 1000; 
-  }    
+    ExposureMillis = (long)(Transition_Exposure * 100);   // deciseconds -> ms
+  }
   if(current_layer > Base_Layer + Transition_Layer)
-    ExposureMillis = Regular_Exposure * 1000;
+    ExposureMillis = Regular_Exposure * 100;   // regular layers: deciseconds -> ms
   
   startTime = millis();
   Duration = 0;

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -182,7 +182,7 @@
   <h2>Print settings</h2>
   <div class='configGrid grid4'>
     <label><span>Layer height (mm)<a href='#' class='qHelp' data-help='layer'>?</a></span><input name='layer_height' id='cfgLayerHeight' type='number' min='0.05' max='0.10' step='0.05'></label>
-    <label><span>Base exposure (s)</span><input name='base_exposure' id='cfgBaseExposure' type='number' min='10' max='60' step='1'></label>
+    <label><span>Base exposure (s)</span><input name='base_exposure' id='cfgBaseExposure' type='number' min='5' max='60' step='1'></label>
     <label><span>Regular exposure (s) <a href='#' id='undoRegExp' class='hidden'></a></span><input name='regular_exposure' id='cfgRegularExposure' type='number' min='1' max='30' step='0.1'></label>
     <label><span>Base layers</span><input name='base_layer' id='cfgBaseLayers' type='number' min='1' max='8' step='1'></label>
     <label><span>Transition layers</span><input name='transition_layer' id='cfgTransitionLayers' type='number' min='0' max='10' step='1'></label>

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -183,7 +183,7 @@
   <div class='configGrid grid4'>
     <label><span>Layer height (mm)<a href='#' class='qHelp' data-help='layer'>?</a></span><input name='layer_height' id='cfgLayerHeight' type='number' min='0.05' max='0.10' step='0.05'></label>
     <label><span>Base exposure (s)</span><input name='base_exposure' id='cfgBaseExposure' type='number' min='10' max='60' step='1'></label>
-    <label><span>Regular exposure (s) <a href='#' id='undoRegExp' class='hidden'></a></span><input name='regular_exposure' id='cfgRegularExposure' type='number' min='1' max='30' step='1'></label>
+    <label><span>Regular exposure (s) <a href='#' id='undoRegExp' class='hidden'></a></span><input name='regular_exposure' id='cfgRegularExposure' type='number' min='1' max='30' step='0.1'></label>
     <label><span>Base layers</span><input name='base_layer' id='cfgBaseLayers' type='number' min='1' max='8' step='1'></label>
     <label><span>Transition layers</span><input name='transition_layer' id='cfgTransitionLayers' type='number' min='0' max='10' step='1'></label>
     <label><span>Slow lift distance (mm)</span><input name='slow_lift_distance' id='cfgSlowLiftDistance' type='number' min='1' max='3' step='1'></label>


### PR DESCRIPTION
0-3: Regular exposure now stored/edited in **deciseconds** (0.1 s); Base stays whole seconds. Includes migration (old whole-second Regular ×10 → ds, self-healing), UVLED timing, transition ramp, estimates, LCD/web edit, backup/undo, and the exp-test LCD display fix.

**Hardware verified (2026-08-08, Sunlu Rapid):**
- #3 real print at Regular 8.0 / Base 18 → clean detail, excellent plate adhesion.
- #6 exposure-test strip → sub-second bars, correct display.
- Migration auto-verified over network (old Regular 14 → 14.0).

firmware-auditor clean; compiles (Flash 70.1%). Gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
