### PR TITLE
0.17: Base exposure undo + partial-config-POST guard

### DIFF
--- a/src/Network.ino
+++ b/src/Network.ino
@@ -1355,6 +1355,8 @@ String configJson() {
   out += String(Regular_Exposure / 10.0, 1);      // 0.17 0-3: seconds (deciseconds/10)
   out += ",\"prevRegularExposure\":";
   out += String(prevRegularExposure / 10.0, 1);   // seconds (0.0 = no undo available)
+  out += ",\"prevBaseExposure\":";
+  out += String(prevBaseExposure);                // seconds (0 = no undo available)
   out += ",\"baseLayers\":";
   out += String(Base_Layer);
   out += ",\"transitionLayers\":";
@@ -1456,10 +1458,26 @@ String configJson() {
   return out;
 }
 
+// HTML varnele, kai ji nuimta, formoje NESIUNCIAMA, tad sis endpoint'as skaite
+// „nera = isjungta". Pultui tai teisinga (jis siuncia visa forma), bet bet kokia
+// dalinė uzklausa isjungdavo visus 13 jungikliu iskart, tarp ju WiFi - printeris
+// dingdavo is tinklo. Taip nutiko du kartus (08-11, 08-12).
+//
+// Pultas savo forma pazymi `form_full`. Be sios zymos varneles, kuriu uzklausoje
+// nera, paliekamos kaip buvo: dalinė uzklausa gali ijungti, bet ne isjungti.
+static bool formFullPost = false;
+static inline bool formCheck(const char *name, bool cur) {
+  if (server.hasArg(name)) return true;
+  return formFullPost ? false : cur;
+}
+
 void applyConfigRequest() {
   float requestedLayer = server.hasArg("layer_height") ? server.arg("layer_height").toFloat() : Layer_Height;
   Layer_Height = requestedLayer < 0.075 ? 0.05 : 0.10;
+  formFullPost = server.hasArg("form_full");   // pultas zymi savo pilna forma
+  long oldBase = Base_Exposure;
   Base_Exposure = formLong("base_exposure", Base_Exposure, 5, 60);   // 0.17 0-3: base min 5 s
+  rememberPrevBaseExposure(oldBase);   // no-op unless it actually changed
   long oldRegular = Regular_Exposure;
   {
     // 0.17 0-3: the form sends Regular in SECONDS (step 0.1); store deciseconds.
@@ -1479,7 +1497,7 @@ void applyConfigRequest() {
   Fast_Lift_Feedrate = formLong("fast_lift_feedrate", Fast_Lift_Feedrate, 20, 50);
   Drop_Back_Feedrate = formLong("drop_back_feedrate", Drop_Back_Feedrate, 20, 50);
   Vat_Capacity_Ml = formLong("vat_ml", Vat_Capacity_Ml, 10, 40);
-  lowResinPauseEnabled = server.hasArg("low_resin_pause");
+  lowResinPauseEnabled = formCheck("low_resin_pause", lowResinPauseEnabled);
   lowResinThresholdMl = formLong("low_resin_ml", lowResinThresholdMl, 1, 3);
   lowResinWarnMl = formLong("low_resin_warn", lowResinWarnMl, 3, 15);   // 0.17 #40: WARN level
   // R-cal: density is a measured property (weigh a known syringe volume), so it
@@ -1491,19 +1509,19 @@ void applyConfigRequest() {
       resinRefitAfterDensityChange();   // samples are grams - re-derive the fit
     }
   }
-  askRefillEnabled = server.hasArg("ask_refill");
-  previewFlip = server.hasArg("preview_flip");
+  askRefillEnabled = formCheck("ask_refill", askRefillEnabled);
+  previewFlip = formCheck("preview_flip", previewFlip);
   uiTimeoutSecs = formLong("ui_timeout", uiTimeoutSecs, 0, 3600);
-  uvLedEnabled = !server.hasArg("dry_run");
-  wifiEnabled = server.hasArg("wifi_enabled");
-  webDashboardEnabled = wifiEnabled && server.hasArg("web_dashboard_enabled");
-  bootUpdateCheckEnabled = server.hasArg("boot_update_check");
-  resumeEnabled = server.hasArg("resume_enabled");
-  resumePrecise = server.hasArg("resume_precise");   // checked = Precise cadence, else Balanced
+  uvLedEnabled = !formCheck("dry_run", !uvLedEnabled);
+  wifiEnabled = formCheck("wifi_enabled", wifiEnabled);
+  webDashboardEnabled = wifiEnabled && formCheck("web_dashboard_enabled", webDashboardEnabled);
+  bootUpdateCheckEnabled = formCheck("boot_update_check", bootUpdateCheckEnabled);
+  resumeEnabled = formCheck("resume_enabled", resumeEnabled);
+  resumePrecise = formCheck("resume_precise", resumePrecise);   // checked = Precise cadence, else Balanced
   pauseLiftMm = formLong("pause_lift", pauseLiftMm, 20, 40);   // 0.17 #82: inspection lift height
   pauseLiftMm = ((pauseLiftMm + 2) / 5) * 5;   // #82: snap to 5 mm so web matches the LCD cycle
-  statsPingEnabled = server.hasArg("stats_ping");
-  mqttEnabled = server.hasArg("mqtt_enabled");
+  statsPingEnabled = formCheck("stats_ping", statsPingEnabled);
+  mqttEnabled = formCheck("mqtt_enabled", mqttEnabled);
   if (!wifiEnabled) mqttEnabled = false;
   mqttHost = formString("mqtt_host", mqttHost, 80);
   mqttPort = formLong("mqtt_port", mqttPort, 1, 65535);
@@ -1513,15 +1531,15 @@ void applyConfigRequest() {
   }
   mqttTopic = formString("mqtt_topic", mqttTopic, 64);
   if (mqttTopic.length() == 0) mqttTopic = "TinyMaker";
-  connectEnabled = server.hasArg("connect_enabled");
+  connectEnabled = formCheck("connect_enabled", connectEnabled);
   if (!wifiEnabled) connectEnabled = false;
   connectBaseUrl = connectNormalizeBaseUrl(formString("connect_base_url", connectBaseUrl, 128));
   connectPrinterName = formString("connect_printer_name", connectPrinterName, 64);
   if (connectEnabled) {
-    connectLeaderboardOptIn = server.hasArg("connect_leaderboard");
+    connectLeaderboardOptIn = formCheck("connect_leaderboard", connectLeaderboardOptIn);
   }
   if (server.hasArg("connect_auto_backup_set")) {
-    connectAutoBackup = server.hasArg("connect_auto_backup");
+    connectAutoBackup = formCheck("connect_auto_backup", connectAutoBackup);
   }
   // One notification channel at a time (radio in the form): Telegram OR
   // WhatsApp OR off. Credentials of the inactive channel are kept.

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -248,6 +248,7 @@ bool dcEnabled = false;             // Discord notifications via a channel webho
 String dcWebhook = "";              // webhook URL (secret - never echoed to browser)
 bool statsPingEnabled = true;       // anonymous install ping (MAC hash + version + print hours)
 uint16_t prevRegularExposure = 0;   // last replaced Regular exposure in DECISECONDS (0 = none) - dashboard Undo
+uint8_t  prevBaseExposure = 0;      // last replaced Base exposure in SECONDS (0 = none) - dashboard Undo
 unsigned long lastUiActivityMs = 0;
 bool uiBlanked = false;
 uint8_t uiSaverPos = 0;               // 0-21 idle screen saver: which of the 5 spots
@@ -295,6 +296,7 @@ void loadDeviceConfig() {
   if (pauseLiftMm < 20 || pauseLiftMm > 40) pauseLiftMm = 20;   // clamp legacy/garbage
   statsPingEnabled = sysPrefs.getBool("statsPing", true);
   prevRegularExposure = sysPrefs.getUShort("prevRegDs", 0);   // 0.17 0-3: deciseconds (new key; old UChar prevRegExp abandoned)
+  prevBaseExposure = sysPrefs.getUChar("prevBaseS", 0);       // sveikos sekundes
   bootAnimName = sysPrefs.getString("bootAnimName", "");
   mqttEnabled = sysPrefs.getBool("mqttEnabled", false);
   mqttHost = sysPrefs.getString("mqttHost", "");
@@ -852,6 +854,16 @@ void rememberPrevRegularExposure(long oldVal) {
   sysPrefs.end();
 }
 
+// Tas pats Base'ui: derinant butent ji dazniausiai persukama, o be atsarginio
+// kelio tenka atsiminti sena reiksme galvoje (V 08-12).
+void rememberPrevBaseExposure(long oldVal) {
+  if (oldVal < 5 || oldVal > 60 || oldVal == Base_Exposure) return;   // sveikos sekundes
+  prevBaseExposure = (uint8_t)oldVal;
+  sysPrefs.begin("tinymaker", false);
+  sysPrefs.putUChar("prevBaseS", prevBaseExposure);
+  sysPrefs.end();
+}
+
 // ===================================================================================
 // Settings backup & restore (flat JSON, on SD or via the dashboard)
 // ===================================================================================
@@ -1162,9 +1174,16 @@ void applyConfigBackup(const String &j) {
   savePrintSettings();
   saveDeviceConfig();
   saveVatRemaining();
+  // Atkurus VISA faila „ankstesne ekspozicijos reiksme" nebeturi prasmes: ji
+  // rodytu ne pries atkurima buvusia, o kazkokia senesne, atsitiktine. Tad
+  // Undo pasiulymus nuimam - jie atsiras vel pakeitus reiksme is pulto.
+  prevRegularExposure = 0;
+  prevBaseExposure = 0;
   sysPrefs.begin("tinymaker", false);
   sysPrefs.putULong("printSecs", totalPrintSecs);
   sysPrefs.putULong("uvLedSecs", totalUvLedSecs);
+  sysPrefs.putUShort("prevRegDs", 0);
+  sysPrefs.putUChar("prevBaseS", 0);
   sysPrefs.end();
 }
 

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -220,7 +220,7 @@
   <h2>Print settings</h2>
   <div class='configGrid grid4'>
     <label><span>Layer height (mm)<a href='#' class='qHelp' data-help='layer'>?</a></span><input name='layer_height' id='cfgLayerHeight' type='number' min='0.05' max='0.10' step='0.05'></label>
-    <label><span>Base exposure (s)</span><input name='base_exposure' id='cfgBaseExposure' type='number' min='5' max='60' step='1'></label>
+    <label><span>Base exposure (s) <a href='#' id='undoBaseExp' class='hidden'></a></span><input name='base_exposure' id='cfgBaseExposure' type='number' min='5' max='60' step='1'></label>
     <label><span>Regular exposure (s) <a href='#' id='undoRegExp' class='hidden'></a></span><input name='regular_exposure' id='cfgRegularExposure' type='number' min='1' max='30' step='0.1'></label>
     <label><span>Base layers</span><input name='base_layer' id='cfgBaseLayers' type='number' min='1' max='8' step='1'></label>
     <label><span>Transition layers</span><input name='transition_layer' id='cfgTransitionLayers' type='number' min='0' max='10' step='1'></label>
@@ -2549,7 +2549,7 @@ const setConfigDisabled=disabled=>{document.querySelectorAll('#pane-print-cal in
 // wiped the printer's settings (2026-07-14 incident). Refuse until loaded.
 const configFormData=()=>{
   if(!connectConfig)throw new Error('Settings have not loaded yet - wait a moment and try again.');
-  const fd=new URLSearchParams(new FormData($('configForm')));fd.append('connect_auto_backup_set','1');return fd;};
+  const fd=new URLSearchParams(new FormData($('configForm')));fd.append('connect_auto_backup_set','1');/* Zyma, kad tai PILNA forma: be jos printeris nuimtu varneliu nelaiko isjungimu (zr. formCheck). */fd.append('form_full','1');return fd;};
 const configIsLocallyLocked=()=>!!(statusData&&statusData.busy);
 const updateNetworkFields=()=>{$('cfgWebDashboardEnabled').disabled=!$('cfgWifiEnabled').checked;};
 const confirmNetworkToggle=async e=>{
@@ -2583,6 +2583,10 @@ const loadConfig=async()=>{
     show('undoRegExp',prevR>0&&prevR!==Number(c.regularExposure));
     $('undoRegExp').textContent='Undo ('+prevR+'s)';
     $('undoRegExp').dataset.v=prevR;
+    const prevB=Number(c.prevBaseExposure)||0;
+    show('undoBaseExp',prevB>0&&prevB!==Number(c.baseExposure));
+    $('undoBaseExp').textContent='Undo ('+prevB+'s)';
+    $('undoBaseExp').dataset.v=prevB;
     $('cfgSlowLiftDistance').value=c.slowLiftDistance; $('cfgFastLiftDistance').value=c.fastLiftDistance; $('cfgSlowLiftFeedrate').value=c.slowLiftFeedrate; $('cfgFastLiftFeedrate').value=c.fastLiftFeedrate; $('cfgDropBackFeedrate').value=c.dropBackFeedrate; $('cfgPauseLift').value=c.pauseLiftMm; $('cfgVatMl').value=c.vatMl; $('cfgLowResinMl').value=c.lowResinMl; $('cfgLowResinWarn').value=c.lowResinWarnMl;
     /* R-cal: dvi eilutes = du firmware slotai tiesiogiai (V 08-10). */
     {const bdg=(c,t)=>'<span class="calBadge '+c+' ">'+t+'</span> ';
@@ -2898,6 +2902,7 @@ $('cfgWebDashboardEnabled').addEventListener('change',confirmNetworkToggle);
 $('cfgMqttEnabled').addEventListener('change',updateMqttFields);
 $('cfgConnectEnabled').addEventListener('change',updateConnectFields);
 $('undoRegExp').addEventListener('click',async e=>{e.preventDefault();const v=Number(e.target.dataset.v)||0;if(!v)return;$('cfgRegularExposure').value=v;try{await api('/api/config',{method:'POST',body:configFormData()});msg('Regular exposure back to '+v+'s.');loadConfig();}catch(err){msg(err.message,true);}});
+$('undoBaseExp').addEventListener('click',async e=>{e.preventDefault();const v=Number(e.target.dataset.v)||0;if(!v)return;$('cfgBaseExposure').value=v;try{await api('/api/config',{method:'POST',body:configFormData()});msg('Base exposure back to '+v+'s.');loadConfig();}catch(err){msg(err.message,true);}});
 $('ntfNone').addEventListener('change',updateTgFields);
 $('ntfTg').addEventListener('change',updateTgFields);
 $('ntfWa').addEventListener('change',updateTgFields);


### PR DESCRIPTION
Follow-up to #97.

## Base exposure undo

Base now has the same one-click undo Regular has: replacing the value from the dashboard remembers the old one and offers **Undo (35s)** beside the field. LCD ±1 steps are not remembered — those are tuning, not a replacement. Undo goes through the same path, so undo-of-undo swaps back.

Restoring a backup now **clears** the undo memory for both Base and Regular. After a wholesale restore the remembered value refers to nothing the user did, and the button would have offered to "undo" to an unrelated older setting. Regular had this flaw too.

## The bug this walked into

An HTML checkbox is simply absent from the form when unticked, so `/api/config` read *missing = off*. Correct for the dashboard, which always posts the whole form — but **any partial POST switched off all fourteen toggles at once**, WiFi and Web control included, and the printer disappeared from the network. Recovery required physical access to the printer's screen.

It happened twice: once via a hand-edited backup file, and once here, sending a two-field form by hand to set up an undo test.

**Fix:** the dashboard marks its form as complete (`form_full`). Without that marker, checkboxes absent from the request keep their current value — a partial request can turn something *on*, but no longer *off*. One-directional, in the safe direction.

The fourteenth switch (`webDashboardEnabled`, written as `wifiEnabled && hasArg(...)`) was missed by the first pass and caught by testing the fix.

## Verification

- `pio run -e tinymaker` — SUCCESS, flash 72.1%.
- Flashed and exercised on the printer.
- The exact request that caused the outage now changes only the exposure and leaves all fourteen switches untouched.
- Base undo confirmed on hardware: 5 → 6 offered "Undo (5s)"; restoring a backup cleared both undo memories.
- Settings verified field-by-field against a pre-test snapshot: all 63 identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)