### PR TITLE
docs: manual - tiesioginis TinyMaker.ini atsisiuntimo linkas

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -288,7 +288,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
   <h2 class="sec" id="print-prusa"><span class="num">6</span>Printing from PrusaSlicer</h2>
   <p>The printer emulates the Prusa SL1 network protocol, so PrusaSlicer’s “Send to printer” works out of the box.</p>
   <ol class="steps">
-    <li>Import the TinyMaker printer profile (<code>TinyMaker.ini</code>, in the repo) via <b>File → Import → Import Config</b>.</li>
+    <li><a href="https://github.com/slibbinas/TinyMakerWifi/raw/main/PrusaSlicer/TinyMaker.ini">Download the TinyMaker printer profile</a> (<code>TinyMaker.ini</code>), then import it via <b>File → Import → Import Config</b>.</li>
     <li><b>Save all three presets.</b> Click the floppy-disk icon next to <i>Print settings</i>, <i>Material</i> and <i>Printer</i> and accept the names. Imported presets are temporary until saved — skip this and PrusaSlicer forgets the printer every time you close it, and you start over.</li>
     <li>Add a <b>physical printer</b>: click the cog next to the printer profile → <b>Add physical printer</b>. Set <b>Hostname</b> to <code>tinymaker.local</code> (or the IP from System → WiFi Info); the API key can be any text.</li>
     <li>Click <b>Test</b> — it should report success (the printer must be on and on WiFi).</li>


### PR DESCRIPTION
Manualas 6 skyriuje sakė „TinyMaker.ini, **in the repo**" - naudotojui tai reiškia eiti į GitHub ir ieškoti failo tarp katalogų. Dabar tai nuoroda: paspaudi ir gauni failą.

**Profilis pats nekeičiamas** ir buvo teisingas - patikrinta visuose trijuose šaltiniuose:

| kur | orientacija | matmenys |
|---|---|---|
| `PrusaSlicer/TinyMaker.ini` | landscape | 320×240 px · 40,8×30,6 mm · `display_mirror_x = 1` |
| `slicer-lab/prusa-full.ini` (etalonas matavimams) | landscape | tie patys |
| WASM variklio rastras (`wasm/bridge.cpp`) | landscape | tie patys |

Renderis patikrintas naršyklėje: nuoroda veikia, stilius toks pat kaip kitų manualo nuorodų. `README.md` sąmoningai paliktas kaip buvo - ten skaitytojas jau yra repo viduje, tad „in the repo" jam teisinga.

Po merge - tą patį vienos eilutės pakeitimą perkelsiu į gh-pages `manual/index.html` (surgical edit, ne kopijavimas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)