### PR TITLE
sessions: main gets the where-am-I tool and the session-start rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,72 @@ debesų sesijoje ar kito žmogaus checkout'e gali jo nebūti — todėl „jei p
 - `origin` → `slibbinas/TinyMakerWiFi` (this fork, active development)
 - `upstream` → `TinyMaker3D/TinyMaker-Open-Source-3D-Printer` (original project)
 
+## Sesijos pradžia: iškart duok darbų sąrašą
+
+**Pirma - paleisk `python scripts/dev/kur_esu.py --sesija <savo-sesijos-vardas>`.**
+Jis pasako sritį, šaką, katalogą, ar medis švarus ir ar šaka apskritai yra GitHub'e.
+Šakų vardai keičiasi (2026-08-23 pervadinti du iš karto), tad atsakymas imamas iš git,
+o ne iš atminties ar iš šio failo.
+
+⚠️ **Skripto įvardyta sritis yra SPĖJIMAS, ne atsakymas.** Jis mato tik šaką ir
+katalogą - kam V atidarė šitą langą, jis nemato. **Patvirtink su V prieš pirmą
+pakeitimą net tada, kai skriptas sritį įvardijo tvirtai.** 2026-08-27 slicerio darbui
+atidaryta sesija atsistojo ant `0.17/slicer-merge`, gavo „SRITIS: Printeris" ir
+patikėjo - visą pusvalandį dirbo ne tos srities darbą.
+
+**`--sesija` nėra papuošalas.** Su juo skriptas pasižymi, kad šis darbo medis užimtas
+(`.claude/uzimta.json`, git jo nemato), ir kita sesija, atsistojusi tame pačiame
+kataloge, gauna įspėjimą. Tą patį vakarą dvi sesijos sėdėjo viename medyje ant tos
+pačios šakos; antroji tai pamatė tik iš to, kad HEAD pajudėjo jai už nugaros. Du
+redaktoriai viename medyje susipjauna: vieno pakeitimai nukrenta į kito commit'ą.
+Pamačiusi tokį įspėjimą, sesija **neima to medžio** - pasiima savo worktree arba
+klausia V, kuri sesija ten lieka.
+
+**Paskui - prisistatyk.** Vienas sakinys: **kuri tai sritis** (printeris / sliceris /
+Connect Live / curing stotelė), kurioje šakoje ir kataloge dirbi. V vienu metu turi
+kelis langus atidarytus, ir iš turinio ne visada aišku, kuris kuris - o supainiojus
+sritį nurodymas nukeliauja ne tai sesijai. **Šaka įvardijama visada**, ne tik sritis:
+„Slicerio sesija, šaka `slcr/dev`, katalogas `C:/PIO-build/exp2-wt`" - be šakos V
+nežino, ar sesija stovi ten, kur guli darbas.
+
+**Nežinai, kuri esi - KLAUSK, nespėk, ir pasiūlyk variantus.** Jei iš šakos, katalogo
+ir istorijos neaišku, kurią sritį sprendi, klausimas turi būti **pasirenkamas meniu**,
+ne atviras klausimas - kad V atsakytų vienu žodžiu, o ne aiškintų:
+
+> Nesuprantu, kuri sritis esu. Kurią imu?
+>
+> | Sritis | Ką ji dirba | Kur |
+> |---|---|---|
+> | **Printeris** | firmware, pultas, docs, leidyba | `prnt/`, pagrindinis katalogas |
+> | **Sliceris** | naršyklės pjaustyklė, WASM modulis | `slcr/`, `C:/PIO-build/exp2-wt` |
+> | **Connect Live** | spausdintuvo valdymas iš interneto | `cliv/`, PR #111 |
+> | **Curing** | plovimo/kietinimo moduliukas | `cure/`, atskira repo `TinyMakerCuring` |
+
+Ir laukti atsakymo. Spėjimas čia pigus tik atrodo: sesija ima ne tos srities darbą,
+dirba valandą, ir tik tada paaiškėja, kad tai buvo kito lango eilė.
+
+**Kiekvienos naujos sesijos PIRMAS dalykas** (po `/clear` ar naujame lange) - dar
+prieš imantis bet ko, pateikti V **numatomų artimiausių darbų sąrašą lentele**:
+
+| Nr | Darbas | Ką tai reiškia |
+|---|---|---|
+| 1 | trumpas pavadinimas | vienas sakinys žmogiška kalba |
+
+Taisyklės sąrašui:
+
+- **Trys iki penkių punktų**, ne daugiau - tai ne visas backlog'as, o „kas toliau".
+- Numeris be aprašymo yra triukšmas: `#116` nieko nesako, `#116 (tuščios atramos)` sako.
+- Jei punktas reikalauja **V sprendimo**, o ne darbo - pažymėk atskirai.
+- Imk iš tikros būsenos: `plan.json`, atviri GitHub issue'ai, savo srities būsenos
+  failas atmintyje. Ne iš antraščių ir ne iš atminties.
+
+**Kodėl:** V dirba su keliomis lygiagrečiomis sesijomis (printeris, sliceris,
+Connect Live, curing). Po `/clear` sesija pati žino, kur sustojo, o V - ne. Tas
+sąrašas yra pirmas dalykas, iš kurio jis mato, ar sesija atsistojo teisingoje
+vietoje, ir gali iškart pasakyti „ne, pirma kitas".
+
+Galioja **visoms** šio projekto sesijoms, ne tik pagrindinei.
+
 ## Tikslinimas iš kodo
 
 Prieš teigdamas ką nors apie kodą (eilutės numerį, funkcijos elgesį,

--- a/scripts/dev/kur_esu.py
+++ b/scripts/dev/kur_esu.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""kur_esu.py - kurioje srityje ir sakoje si sesija dirba.
+
+Sesijos pradzioje (zr. CLAUDE.md „Sesijos pradzia") reikia prisistatyti: kuri
+sritis, kuri saka, koks katalogas. Saku vardai keiciasi - 2026-08-23 pervadinom
+du is karto - tad atsakymas imamas is git, ne is atminties.
+
+    python scripts/dev/kur_esu.py --sesija <sesijos-vardas>
+
+Isvestis tycia trumpa: viena eilute prisistatymui + kontekstas po ja.
+
+DU dalykai, kuriu skriptas NEGALI zinoti, tad ir nesideda zinantis:
+
+1. Sritis cia yra SPEJIMAS is sakos ir katalogo. Skriptas nemato, kam V atidare
+   langa. 2026-08-27 sesija, atidaryta slicerio darbui, atsistojo ant sakos
+   0.17/slicer-merge, gavo "SRITIS: Printeris" ir patikejo - nes ankstesne
+   versija sriti spausdino kaip fakta, be jokio "gal". Todel dabar salia visada
+   eina pagrindas ir prasymas patvirtinti su V.
+
+2. Ar tame paciame darbo medyje jau sedi kita sesija. Tam yra zyme: su --sesija
+   skriptas irašo .claude/uzimta.json (git jo nemato, zr. .gitignore), ir kita
+   sesija, atsistojusi tame paciame kataloge, gauna perspejima. Tas pats
+   2026-08-27: dvi sesijos vienoje sakoje ir viename medyje.
+"""
+import io
+import json
+import os
+import subprocess
+import sys
+import time
+
+# Sritis atpazistama pagal sakos priesdeli; kelias - atsarginis kelias tiems
+# atvejams, kai saka dar nepervadinta pagal nauja sistema.
+BY_PREFIX = {
+    "prnt/": "Printeris",
+    "slcr/": "Sliceris",
+    "cliv/": "Connect Live",
+    "cure/": "Curing stotele",
+}
+BY_PATH = {
+    "tinymakercuring": "Curing stotele",
+    "exp2-wt": "Sliceris",
+    "s3-wt": "Sliceris (laboratorija)",
+    "ghp-wt": "Leidyba (gh-pages)",
+}
+# Senos, dar nepervadintos sakos - kad sesija nesiblaskytu.
+LEGACY = {
+    "feature/connect-live": ("Connect Live", "turi buti pervadinta i cliv/gateway (issue 114)"),
+    "experimental2": ("Sliceris", "pervadinta i slcr/dev 2026-08-23"),
+    "slicer3": ("Sliceris", "pervadinta i slcr/lab 2026-08-23"),
+}
+
+
+# Kiek laiko svetimos sesijos zyme dar laikoma gyva. Ilgiau pasedejusi zyme
+# greiciausiai likusi nuo uzdarytos sesijos, ir triuksmauti del jos nebeverta.
+ZYME_GYVA_H = 8
+
+
+def zymes_kelias(root):
+    return os.path.join(root, ".claude", "uzimta.json")
+
+
+def zyme_skaityk(root):
+    try:
+        return json.load(io.open(zymes_kelias(root), encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def zyme_rasyk(root, sesija, branch):
+    try:
+        d = os.path.dirname(zymes_kelias(root))
+        if not os.path.isdir(d):
+            os.makedirs(d)
+        with io.open(zymes_kelias(root), "w", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "sesija": sesija,
+                "saka": branch,
+                "laikas": time.strftime("%Y-%m-%d %H:%M"),
+                "epoch": int(time.time()),
+            }, ensure_ascii=False, indent=2))
+    except Exception:
+        pass  # zyme yra patogumas, ne butinybe - del jos skriptas negriuva
+
+
+def amzius(zyme):
+    """Zymes amzius valandomis (float) arba None, jei nesuprantama."""
+    try:
+        return (time.time() - float(zyme.get("epoch", 0))) / 3600.0
+    except Exception:
+        return None
+
+
+def git(*args):
+    try:
+        out = subprocess.check_output(("git",) + args, stderr=subprocess.STDOUT)
+        return out.decode("utf-8", "replace").strip()
+    except Exception:
+        return ""
+
+
+def say(text):
+    sys.stdout.buffer.write((text + "\n").encode("utf-8", "replace"))
+
+
+def main():
+    sesija = ""
+    if "--sesija" in sys.argv:
+        i = sys.argv.index("--sesija")
+        if i + 1 < len(sys.argv):
+            sesija = sys.argv[i + 1]
+
+    branch = git("branch", "--show-current") or "(detached HEAD)"
+    root = git("rev-parse", "--show-toplevel") or os.getcwd()
+    # Worktree kataloge basename yra worktree vardas, ne repo - imam is remote.
+    origin = git("remote", "get-url", "origin")
+    repo = os.path.basename(origin).replace(".git", "") if origin else os.path.basename(root)
+    head = git("log", "-1", "--format=%h %s")
+    upstream = git("rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+    dirty = git("status", "--porcelain")
+
+    sritis, pastaba, pagrindas = None, "", ""
+    for pref, name in BY_PREFIX.items():
+        if branch.startswith(pref):
+            sritis = name
+            pagrindas = 'saka prasideda "%s"' % pref
+            break
+    if sritis is None and branch in LEGACY:
+        sritis, pastaba = LEGACY[branch]
+        pagrindas = "senas sakos vardas"
+    if sritis is None:
+        low = root.replace("\\", "/").lower()
+        for key, name in BY_PATH.items():
+            if key in low:
+                sritis = name
+                pagrindas = 'kataloge yra "%s"' % key
+                break
+    if sritis is None and branch in ("main", "experimental") or branch.startswith("0.17/"):
+        sritis = "Printeris"
+        pagrindas = pagrindas or 'saka "%s" - atsarginis spejimas, ne taisykle' % branch
+
+    say("")
+    if sritis:
+        say("  SRITIS:   %s   (spejimas: %s)%s"
+            % (sritis, pagrindas or "nezinia is ko", ("  [%s]" % pastaba) if pastaba else ""))
+    else:
+        say("  SRITIS:   NEAISKU - klausk V ir pasiulyk meniu (zr. CLAUDE.md)")
+    say("  SAKA:     %s" % branch)
+    say("  KATALOGAS: %s" % root)
+    say("  REPO:     %s" % repo)
+    say("")
+    if upstream:
+        ab = git("rev-list", "--left-right", "--count", "%s...%s" % (branch, upstream))
+        say("  nutolusi: %s   (priekyje/atsilieka: %s)" % (upstream, ab.replace("\t", " / ") or "?"))
+    else:
+        say("  nutolusi: NERA - sios sakos GitHub'e dar nera, darbas tik siame diske")
+    say("  HEAD:     %s" % head)
+    say("  medis:    %s" % ("svarus" if not dirty else "NESVARUS (%d failai)" % len(dirty.splitlines())))
+    say("")
+
+    # Palyginam su uzfiksuotu kanonu: pasenes irasas turi issiduoti PATS.
+    reg = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sritys.json")
+    if os.path.isfile(reg):
+        try:
+            data = json.load(io.open(reg, encoding="utf-8"))
+        except Exception as e:
+            say("  (!) sritys.json neperskaitomas: %s" % e)
+            data = None
+        if data:
+            rec = None
+            for it in data.get("sritys", []):
+                if sritis and it.get("sritis", "").lower().startswith(sritis.split()[0].lower()):
+                    rec = it
+                    break
+            if rec:
+                if rec.get("saka") != branch:
+                    say("  (!) SRITYS.JSON PASENES: uzfiksuota saka '%s', realiai '%s'."
+                        % (rec.get("saka"), branch))
+                    say("      Atnaujink scripts/dev/sritys.json tame paciame commit'e.")
+                if rec.get("pastaba"):
+                    say("  pastaba:  %s" % rec["pastaba"])
+                say("")
+            elif sritis:
+                say("  (!) sritys.json neturi irašo sriciai '%s' - pridek." % sritis)
+                say("")
+
+    # Sritis yra spejimas, ir taip ir turi atrodyti - kitaip sesija ja perskaito
+    # kaip atsakyma ir nebeklausia (taip ir nutiko 2026-08-27).
+    say("  (!) SRITIS - SPEJIMAS. Skriptas mato tik saka ir kataloga; kam V atidare")
+    say("      si langa, jis nemato. Paklausk V, ar sritis teisinga, PRIES pirma")
+    say("      pakeitima (CLAUDE.md 'Sesijos pradzia').")
+    say("")
+
+    # Uzimtumo zyme: ar siame medyje jau sedi kita sesija.
+    sena = zyme_skaityk(root)
+    if sena and sena.get("sesija") and sena.get("sesija") != sesija:
+        val = amzius(sena)
+        if val is None or val < ZYME_GYVA_H:
+            if val is None:
+                kada = sena.get("laikas", "?")
+            elif val < 1:
+                kada = "pries %d min" % int(val * 60)
+            else:
+                kada = "pries %.1f val" % val
+            say("  (!!) SI DARBO MEDI JAU PASIEME KITA SESIJA")
+            say("       sesija:  %s" % sena["sesija"])
+            say("       saka:    %s   (%s, %s)" % (sena.get("saka", "?"),
+                                                   sena.get("laikas", "?"), kada))
+            say("       Du redaktoriai viename medyje susipjauna: vieno pakeitimai")
+            say("       nukrenta i kito commit'a. Imk sau atskira worktree arba")
+            say("       susitark su V, kuri sesija cia lieka.")
+            say("")
+    if sesija:
+        zyme_rasyk(root, sesija, branch)
+    else:
+        say("  (i) Zyme neirasyta: paleisk su --sesija <savo-vardas>, kad kita sesija")
+        say("      matytu, jog sis medis uzimtas.")
+        say("")
+
+    wt = git("worktree", "list")
+    if wt:
+        say("  Kitos sio repo darbo vietos:")
+        for line in wt.splitlines():
+            mark = " <-- cia" if line.startswith(root.replace("/", "\\")) or root in line.replace("\\", "/") else ""
+            say("    %s%s" % (line, mark))
+        say("")
+    say("  Curing gyvena ATSKIROJE repo: Documents/PlatformIO/Projects/TinyMakerCuring")
+    say("")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/sritys.json
+++ b/scripts/dev/sritys.json
@@ -1,0 +1,52 @@
+{
+  "_doc": [
+    "KANONAS: kuri saka kuriai sriciai priklauso SIANDIEN.",
+    "Pervadinai saka arba perkelei darba i kita - atnaujink CIA, tame paciame commit'e.",
+    "scripts/dev/kur_esu.py si faila skaito ir PERSPEJA, jei tikrove nesutampa su irasu,",
+    "tad pasenes irasas issiduoda pats, o ne po dvieju savaiciu."
+  ],
+  "_atnaujinta": "2026-08-23",
+  "sritys": [
+    {
+      "sritis": "Printeris",
+      "priesdelis": "prnt/",
+      "saka": "0.17/slicer-merge",
+      "katalogas": "Documents/PlatformIO/Projects/TinyMakerWiFi",
+      "repo": "TinyMakerWifi",
+      "uz_ka": "firmware, pultas, dokumentacija, leidyba",
+      "pastaba": "0.17 integracine saka - joje VISKAS, kas ruosiama testams. Po isleidimo darbas pereis i prnt/0.18-*"
+    },
+    {
+      "sritis": "Sliceris",
+      "priesdelis": "slcr/",
+      "saka": "slcr/dev",
+      "katalogas": "C:/PIO-build/exp2-wt",
+      "repo": "TinyMakerWifi",
+      "uz_ka": "narsykles pjaustykle, WASM modulis",
+      "pastaba": "iki 2026-08-23 vadinosi experimental2. Laboratorija: slcr/lab (C:/PIO-build/s3-wt)"
+    },
+    {
+      "sritis": "Connect Live",
+      "priesdelis": "cliv/",
+      "saka": "cliv/gateway",
+      "katalogas": "(nuolatinio nera - debesu sesijos)",
+      "repo": "TinyMakerWifi",
+      "uz_ka": "spausdintuvo matymas ir valdymas is interneto",
+      "pastaba": "iki 2026-08-23 vadinosi feature/connect-live (issue 114); pervadinta per API ir PR 111 uzsidare, tesinys PR 117 - saka su atviru PR pervadinti TIK narsykleje. NE tas pats, kas TinyMaker Connect - tas yra Briano serveris modeliu dalijimuisi"
+    },
+    {
+      "sritis": "Curing stotele",
+      "priesdelis": "cure/",
+      "saka": "main",
+      "katalogas": "Documents/PlatformIO/Projects/TinyMakerCuring",
+      "repo": "TinyMakerCuring",
+      "uz_ka": "plovimo ir kietinimo moduliukas (ESP32 + sava plokste)",
+      "pastaba": "ATSKIRA PRIVATI repo, ne sio repo saka. Su 0.17 nesusijusi"
+    }
+  ],
+  "pagrindines": {
+    "main": "stabilus leidimas, apsaugotas CI",
+    "experimental": "dideliu darbu linija",
+    "gh-pages": "leidyba: manualas, landing, firmware .bin, slicerio modulis"
+  }
+}


### PR DESCRIPTION
A session standing on `main` had no way to tell which area it belonged to and no way to say it had taken a working tree.

Both gaps cost real time already:

- **2026-08-27** - a session opened for slicer work stood on a printer branch, read the area as fact, and spent half an hour on the wrong area's work.
- **The same evening** - two sessions sat in one worktree on one branch; the second noticed only because HEAD moved behind its back.

The fix was written on the printer branch (PR #120) and never travelled. This carries it to `main`:

| File | What it does |
|---|---|
| `scripts/dev/kur_esu.py` | says area / branch / directory, prints the area **as a guess with its grounds**, and with `--sesija <name>` marks the tree as taken (`.claude/uzimta.json`, gitignored) so the next session gets a warning |
| `scripts/dev/sritys.json` | which branch belongs to which area today |
| `CLAUDE.md` | the "Sesijos pradžia" rule that tells a session to run it with `--sesija` and to confirm the area with V |

Docs and one dev script - **no firmware is touched**, so the compile is unaffected.

The branch table comes from `cliv/gateway`, not from the printer branch: the printer copy still names the Connect Live branch `feature/connect-live`, which no longer exists.

Same change is now on `experimental`, `cliv/gateway`, `slcr/dev` and `slcr/lab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)