### PR TITLE
sessions: kur_esu.py stops crying wolf about the branch table

### DIFF
--- a/scripts/dev/kur_esu.py
+++ b/scripts/dev/kur_esu.py
@@ -21,6 +21,11 @@ DU dalykai, kuriu skriptas NEGALI zinoti, tad ir nesideda zinantis:
    skriptas irašo .claude/uzimta.json (git jo nemato, zr. .gitignore), ir kita
    sesija, atsistojusi tame paciame kataloge, gauna perspejima. Tas pats
    2026-08-27: dvi sesijos vienoje sakoje ir viename medyje.
+
+Kanono patikra (sritys.json) tyli trimis atvejais, nes ju nei vienas nera
+pasenes irasas: laikina sesijos saka, antra tos pacios srities saka (slcr/lab
+salia slcr/dev) ir bendra main/experimental. Garsus ispejimas paliktas tikram
+pervadinimui - kitaip jis degtu kaskart, o degantis visada nebematomas.
 """
 import io
 import json
@@ -103,6 +108,20 @@ def say(text):
     sys.stdout.buffer.write((text + "\n").encode("utf-8", "replace"))
 
 
+def saka_yra_nutolusi(branch):
+    """Ar tokia saka guli GitHub'e.
+
+    Imam vietine nutolusiu saku kopija (refs/remotes/origin/...), ne `ls-remote` -
+    veikia ir be tinklo, ir nekainuoja sekundes kiekvienam sesijos startui.
+    Sviezumas cia nesvarbus: klausiam tik „ar tai nuolatine saka, ar sesijos
+    laikinoji", ne „ar sutampa commit'ai".
+    """
+    if not branch or branch.startswith("("):
+        return False
+    return bool(git("rev-parse", "--verify", "--quiet",
+                    "refs/remotes/origin/%s" % branch))
+
+
 def main():
     sesija = ""
     if "--sesija" in sys.argv:
@@ -173,9 +192,29 @@ def main():
                     rec = it
                     break
             if rec:
-                if rec.get("saka") != branch:
-                    say("  (!) SRITYS.JSON PASENES: uzfiksuota saka '%s', realiai '%s'."
-                        % (rec.get("saka"), branch))
+                # sritys.json laiko NAMU saka. Sesija gali teisetai sedeti kitoje:
+                # laikinoje savo worktree sakoje, antroje tos pacios srities sakoje
+                # (slcr/lab salia slcr/dev) arba bendroje main/experimental. Nei
+                # vienas is tu atveju nera pasenes kanonas, o ispejimas, kuris dega
+                # visada, per savaite tampa nematomas - ir tada pradings tikras
+                # pervadinimas, del kurio si patikra apskritai atsirado (08-23).
+                namu = rec.get("saka")
+                pref = rec.get("priesdelis") or ""
+                bendros = data.get("pagrindines", {})
+                if namu == branch:
+                    pass
+                elif branch.startswith("claude/") or not saka_yra_nutolusi(branch):
+                    say("  laikina:  darbo saka '%s' GitHub'e dar neguli; namu saka - "
+                        "'%s', kanonas sutampa" % (branch, namu))
+                elif pref and branch.startswith(pref):
+                    say("  antra saka: dirbama '%s', tos pacios srities namu saka - "
+                        "'%s'. Ne pasenimas" % (branch, namu))
+                elif branch in bendros:
+                    say("  bendra saka: dirbama '%s' (%s); srities namu saka - '%s'"
+                        % (branch, bendros[branch], namu))
+                else:
+                    say("  (!) SRITYS.JSON PASENES: uzfiksuota saka '%s', realiai '%s' "
+                        "(pervadinta?)." % (namu, branch))
                     say("      Atnaujink scripts/dev/sritys.json tame paciame commit'e.")
                 if rec.get("pastaba"):
                     say("  pastaba:  %s" % rec["pastaba"])

--- a/scripts/dev/sritys.json
+++ b/scripts/dev/sritys.json
@@ -3,9 +3,12 @@
     "KANONAS: kuri saka kuriai sriciai priklauso SIANDIEN.",
     "Pervadinai saka arba perkelei darba i kita - atnaujink CIA, tame paciame commit'e.",
     "scripts/dev/kur_esu.py si faila skaito ir PERSPEJA, jei tikrove nesutampa su irasu,",
-    "tad pasenes irasas issiduoda pats, o ne po dvieju savaiciu."
+    "tad pasenes irasas issiduoda pats, o ne po dvieju savaiciu.",
+    "Laukas 'saka' = NAMU saka, kur srities darbas galiausiai sugula. Sesija gali teisetai",
+    "sedeti kitoje (laikinoje, antroje tos pacios srities, bendroje main/experimental) -",
+    "tai ne pasenimas, ir kur_esu.py tokiais atvejais tyli."
   ],
-  "_atnaujinta": "2026-08-23",
+  "_atnaujinta": "2026-09-02",
   "sritys": [
     {
       "sritis": "Printeris",


### PR DESCRIPTION
The stale-canon warning in `scripts/dev/kur_esu.py` fired whenever a session stood on a branch other than the one recorded in `scripts/dev/sritys.json`. Three of those cases are normal work, not a stale record:

- a temporary session branch (not on GitHub yet, or `claude/…`),
- a second branch of the same area - `slcr/lab` next to `slcr/dev`, which is where every slicer lab session sits,
- a shared trunk: `main`, `experimental`, `gh-pages`.

A warning that fires always is a warning nobody reads, and the real thing it guards (the 2026-08-23 renames) would then go unnoticed.

**What changed**

- `sritys.json` `_doc` now states that `saka` is the **home** branch, and that working elsewhere is legitimate.
- `kur_esu.py` answers those three cases with a quiet one-line note and keeps the loud `SRITYS.JSON PASENES` warning - now with `(pervadinta?)` - for an actual rename.
- Branch existence is read from `refs/remotes/origin/*` instead of `ls-remote`: works offline, no network round trip at session start.

**Verified in the live worktrees**

| Tree | Branch | Result |
|---|---|---|
| `s3-wt` | `slcr/lab` | quiet `antra saka` (was the false alarm) |
| `exp2-wt` | `slcr/dev` | silent |
| main dir | `0.17/slicer-merge` | silent |
| `ghp-wt` | `gh-pages` | quiet `bendra saka` |
| forged stale record | `0.17/slicer-merge` | still shouts, with `(pervadinta?)` |

Origin: the Curing session hit this first and fixed it in `TinyMakerCuring` (`4c59514`); its filter did not cover our permanent second branches, so the same-prefix case is added here. The slicer session relayed it and is waiting to carry this version back to the Curing copy so the two do not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)