### PR TITLE
sessions: the temporary-branch note stops claiming something it never checked

### DIFF
--- a/scripts/dev/kur_esu.py
+++ b/scripts/dev/kur_esu.py
@@ -204,8 +204,13 @@ def main():
                 if namu == branch:
                     pass
                 elif branch.startswith("claude/") or not saka_yra_nutolusi(branch):
-                    say("  laikina:  darbo saka '%s' GitHub'e dar neguli; namu saka - "
-                        "'%s', kanonas sutampa" % (branch, namu))
+                    # Priezastis sakoma ta, kuri tikrai patikrinta: "claude/" saka
+                    # atpazistama is vardo ir GitHub'e ji kaip tik daznai guli
+                    # (debesu sesijos), tad apie GitHub'a cia netvirtinam nieko.
+                    kodel = ("sesijos darbo saka" if branch.startswith("claude/")
+                             else "GitHub'e jos nera")
+                    say("  laikina:  darbo saka '%s' (%s); namu saka - '%s', "
+                        "kanonas sutampa" % (branch, kodel, namu))
                 elif pref and branch.startswith(pref):
                     say("  antra saka: dirbama '%s', tos pacios srities namu saka - "
                         "'%s'. Ne pasenimas" % (branch, namu))


### PR DESCRIPTION
Follow-up to #125, spotted by the slicer session while carrying that patch into `slcr/dev`, `slcr/lab` and the Curing repo.

For a branch named `claude/…` the note read *"GitHub'e dar neguli"* - but that case is recognised from the name alone and never checked against the remote. Cloud-session branches are usually pushed, so the line stated something false. The behaviour was right; only the sentence was.

Now each case gives the reason that was actually verified:

- `claude/…` -> `darbo saka 'claude/x' (sesijos darbo saka)`
- no remote ref -> `darbo saka 'prnt/x' (GitHub'e jos nera)`

Verified by running it: a `claude/` branch in a slicer-path worktree prints the first line, this PR's own branch (not yet pushed at the time) printed the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)