### PR TITLE
sessions: a branch that no longer exists is heard again

### DIFF
--- a/scripts/dev/kur_esu.py
+++ b/scripts/dev/kur_esu.py
@@ -22,10 +22,12 @@ DU dalykai, kuriu skriptas NEGALI zinoti, tad ir nesideda zinantis:
    sesija, atsistojusi tame paciame kataloge, gauna perspejima. Tas pats
    2026-08-27: dvi sesijos vienoje sakoje ir viename medyje.
 
-Kanono patikra (sritys.json) tyli trimis atvejais, nes ju nei vienas nera
-pasenes irasas: laikina sesijos saka, antra tos pacios srities saka (slcr/lab
-salia slcr/dev) ir bendra main/experimental. Garsus ispejimas paliktas tikram
-pervadinimui - kitaip jis degtu kaskart, o degantis visada nebematomas.
+Kanono patikra (sritys.json) pirmiausia klausia, ar uzfiksuota saka apskritai
+dar egzistuoja - jei nebera, tai pasenes irasas, ir jokia isimtis to nedengia.
+Tik po to tyli trys atvejai, kuriu nei vienas nera pasenimas: laikina sesijos
+saka, antra tos pacios srities saka (slcr/lab salia slcr/dev) ir bendra
+main/experimental. Garsus ispejimas paliktas tikram pervadinimui - kitaip jis
+degtu kaskart, o degantis visada nebematomas.
 """
 import io
 import json
@@ -122,6 +124,21 @@ def saka_yra_nutolusi(branch):
                     "refs/remotes/origin/%s" % branch))
 
 
+def saka_yra(branch):
+    """Ar tokia saka apskritai egzistuoja - vietoje ARBA GitHub'e.
+
+    Sito klausiam apie sritys.json IRASA, ne apie darbo saka: jei uzfiksuotos
+    sakos niekur nebera, irasas pasenes, ir tai turi rekti nepriklausomai nuo to,
+    kurioje sakoje sesija sedi. 2026-09-02: be sio klausimo tylieji atvejai
+    pridengdavo tikra pasenima - sesija ant slcr/dev su irasu "experimental2"
+    (pervadinta 08-23) gaudavo rami "Ne pasenimas".
+    """
+    if not branch or branch.startswith("("):
+        return False
+    return bool(git("rev-parse", "--verify", "--quiet", "refs/heads/%s" % branch)
+                or saka_yra_nutolusi(branch))
+
+
 def main():
     sesija = ""
     if "--sesija" in sys.argv:
@@ -203,6 +220,13 @@ def main():
                 bendros = data.get("pagrindines", {})
                 if namu == branch:
                     pass
+                elif not saka_yra(namu):
+                    # PIRMAS klausimas: ar uzfiksuota saka apskritai dar yra. Jei
+                    # nebera - irasas pasenes, ir tylios isimtys jo dengti negali.
+                    say("  (!) SRITYS.JSON PASENES: uzfiksuotos sakos '%s' nebera nei "
+                        "vietoje, nei GitHub'e (pervadinta?)." % namu)
+                    say("      Dirbama '%s'. Atnaujink scripts/dev/sritys.json tame "
+                        "paciame commit'e." % branch)
                 elif branch.startswith("claude/") or not saka_yra_nutolusi(branch):
                     # Priezastis sakoma ta, kuri tikrai patikrinta: "claude/" saka
                     # atpazistama is vardo ir GitHub'e ji kaip tik daznai guli


### PR DESCRIPTION
Regression from #125, found by the Curing session and measured in our own tree.

With `sritys.json` still naming `experimental2` (renamed away on 2026-08-23; absent from both `refs/heads` and `origin`), a session on `slcr/dev` was told:

```
antra saka: dirbama 'slcr/dev', tos pacios srities namu saka - 'experimental2'. Ne pasenimas
```

Not merely silent - it asserted all was well and named a branch that does not exist. That is exactly the case the check was built for after the 08-23 renames.

**Cause.** The Curing version asked *"does the recorded branch exist at all?"* first. Merging the two logics dropped that question, so the same-prefix exception from #125 ran ahead of it and covered a genuinely stale record.

**Fix.** `saka_yra()` is back and asked first, against `refs/heads/<b>` and `refs/remotes/origin/<b>`. If the recorded home branch is gone anywhere, the warning is loud regardless of which branch the session sits on. The three quiet cases are untouched.

**Verified by running, case by case**

| Case | Result |
|---|---|
| stale record (`experimental2`), session on `slcr/dev` | loud, names both branches |
| `slcr/lab`, correct record | quiet `antra saka` |
| `slcr/dev`, `0.17/slicer-merge` | silent |
| unpushed branch | `laikina … (GitHub'e jos nera)` |
| `claude/…` branch | `laikina … (sesijos darbo saka)` |

The slicer session is waiting on this to carry it into `slcr/dev`, `slcr/lab` and the Curing repo, where the same bug is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)