### PR TITLE
print: a Stop or a power cut during a pause move no longer misleads or crashes the plate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ the upstream TinyMaker3D firmware is `1.0.2`. Format follows
 Credits: features are by **Viktoras Šidlauskas ([@slibbinas](https://github.com/slibbinas))**
 unless noted. Community contributors are tagged inline.
 
+## [Unreleased]
+
+### Fixed
+
+- **A dashboard Stop pressed while the plate rose into a pause showed "Paused".** The
+  print did stop, but once the plate reached the pause height the pause was parked
+  anyway: for the ~24 s final lift the dashboard said "Paused" with **Resume** live and
+  the printer screen showed the pause icons (a resin pause would also have sent its
+  refill message to Telegram). A stopped print now stays "Canceling..." to the end.
+  Stop from the printer's own buttons was not affected - they are not read during that
+  lift.
+
 ## [0.17.0] - 2026-09-11 (beta)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ unless noted. Community contributors are tagged inline.
   where it is and says "Raise the plate" - lift it with the manual lift. A pause in such
   a print also lifts the plate no higher than 62 mm (instead of 68 mm), to leave room
   for the small height error.
+- **"Lift plate only" after a power cut stops short of the top, and can be stopped.** That
+  lift runs on an estimated height, and the Z axis has only 3 mm of travel above its
+  68 mm limit (measured), so it now stops 6 mm lower. The screen says "Watch it - BACK
+  stops", and BACK does stop the move.
 - **A power cut during a long plate move no longer offers a risky resume.** While the
   plate rises into a pause, travels back down after Resume, or rises at the end of a
   print, its real height does not match the one saved for resuming, and resuming could

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ unless noted. Community contributors are tagged inline.
 - **The same after Resume.** A dashboard Stop pressed while the plate travelled back
   down stopped the print, but once the plate arrived the printer screen redrew live
   Stop and Pause buttons next to "Canceling...". They now stay grey to the end.
+- **After a print resumed from a power cut, the plate is no longer raised at the end.**
+  After such a resume the plate's height is only an estimate, and the lift to the top
+  could drive the plate into the top of its travel. The printer now leaves the plate
+  where it is and says "Raise the plate" - lift it with the manual lift. A pause in such
+  a print also lifts the plate no higher than 62 mm (instead of 68 mm), to leave room
+  for the small height error.
+- **A power cut during a long plate move no longer offers a risky resume.** While the
+  plate rises into a pause, travels back down after Resume, or rises at the end of a
+  print, its real height does not match the one saved for resuming, and resuming could
+  press the part into the screen or drive the plate into the top. The saved point is
+  now dropped before those moves and written again when the plate stops, so a cut
+  there simply boots normally.
 
 ## [0.17.0] - 2026-09-11 (beta)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ unless noted. Community contributors are tagged inline.
   refill message to Telegram). A stopped print now stays "Canceling..." to the end.
   Stop from the printer's own buttons was not affected - they are not read during that
   lift.
+- **The same after Resume.** A dashboard Stop pressed while the plate travelled back
+  down stopped the print, but once the plate arrived the printer screen redrew live
+  Stop and Pause buttons next to "Canceling...". They now stay grey to the end.
 
 ## [0.17.0] - 2026-09-11 (beta)
 

--- a/src/Motor.ino
+++ b/src/Motor.ino
@@ -518,7 +518,29 @@ void lift_finished_print(){
      and let the user raise it (the manual jog is unclamped while unhomed). A normal print
      homes before its first layer, so it keeps the lift. (V: power trouble outside the
      layers is the user's to sort out - keep this simple.) */
-  if (!zHomed) return;
+  if (!zHomed) {
+    // Say so: a plate left in the vat with no word reads as a fault, and starting the
+    // next print unlifted would home it down onto the part (audit 2026-09-12).
+    // "Raise the plate" is shorter than the 119 px "Plate is at the top" - it fits.
+    screenPlateNote("Raise the plate");
+    // ~2.4 s more on screen (~3.5 s in all), still answering the dashboard every 200 ms:
+    // a bare delay here plus the Telegram send right after it would be ~6-8 s of
+    // silence - the "Printer not answering" gap measured 2026-09-01 (audit 2026-09-12).
+    {
+      unsigned long noteT0 = millis(), svc = 0;
+      while (millis() - noteT0 < 2400) {
+        #if ENABLE_NETWORK
+        if (millis() - svc >= 200) { svc = millis(); network_service_http(); }
+        #endif
+        delay(10);
+      }
+    }
+    return;
+  }
+  // No resume across the final lift: the card still holds the last layer's height while
+  // the plate rises toward the top, and "Lift plate only" after a power cut here would
+  // add 20 mm on top of the real height (V 2026-09-12). The print ends right after it.
+  resumeClear();
   /* Dry run pabaigoje (ir ji atsaukus) kelti iki pat virsaus nera ko: nieko
      neatspausdinta, nuimti nera ko, o kelias uztrunka desimtis sekundziu ir testuojant
      kartojasi be galo (V 08-13). Keliam iki „Pause lift height" - tiek, kad plokste

--- a/src/Motor.ino
+++ b/src/Motor.ino
@@ -509,6 +509,16 @@ void publishPauseEstimate(int fromPhase) {
 }
 
 void lift_finished_print(){
+  /* After a power-loss resume the height is only the checkpoint's estimate: recovery
+     never homes (zHomed stays false), and the estimate is kept LOW on purpose so it
+     cannot drive the plate into the part. Lifting to the absolute max_height from a low
+     estimate drove the plate past the top of the Z travel - it hit the top and the motor
+     stalled (2026-09-12, Stop after a resumed print). The last layer's peel has already
+     run by the time we get here, so nothing needs this lift: leave the plate where it is
+     and let the user raise it (the manual jog is unclamped while unhomed). A normal print
+     homes before its first layer, so it keeps the lift. (V: power trouble outside the
+     layers is the user's to sort out - keep this simple.) */
+  if (!zHomed) return;
   /* Dry run pabaigoje (ir ji atsaukus) kelti iki pat virsaus nera ko: nieko
      neatspausdinta, nuimti nera ko, o kelias uztrunka desimtis sekundziu ir testuojant
      kartojasi be galo (V 08-13). Keliam iki „Pause lift height" - tiek, kad plokste

--- a/src/Resume.ino
+++ b/src/Resume.ino
@@ -223,12 +223,14 @@ void resumeRaisePlateAndDiscard() {
   gfx2->setFont(&FreeSans8pt7b);
   gfx2->setTextColor(WHITE);
   gfx2->setTextSize(1);
-  /* Two lines, both inside the 156 px frame: the plate is about to move on an
-     ESTIMATED height, so the operator is told to watch it and how to stop it
-     (V 2026-09-12). Widths against "Plate is at the top" = 119 px for 19 chars. */
+  /* Two lines on the 160 px screen (no frame here, just fillScreen): the plate is about
+     to move on an ESTIMATED height, so the operator is told to watch it and how to stop
+     it (V 2026-09-12). Measured from FreeSans8pt7b: "Raising plate." at x=8 ends at 102,
+     "Watch it - BACK stops" is 155 px of ink - at x=8 it would run 3 px off the edge, so
+     it starts at x=2 (audit 2026-09-12). */
   gfx2->setCursor(8, 30);
   gfx2->print("Raising plate.");
-  gfx2->setCursor(8, 56);
+  gfx2->setCursor(2, 56);
   gfx2->print("Watch it - BACK stops");
 
   // Discard the checkpoint BEFORE moving: UP = "do not resume", so a power
@@ -268,11 +270,15 @@ void resumeRaisePlateAndDiscard() {
     stepper.moveTo(target);
     while (stepper.distanceToGo() != 0) {
       stepper.run();
-      if (digitalRead(buttonBack) == LOW) break;
+      if (digitalRead(buttonBack) == LOW) { stopped = true; break; }
     }
   }
   stepper.disableOutputs();
   delay(200);
+  /* Stopped by hand: the plate stands wherever it stopped and can still be stuck to the
+     FEP, and the boot path draws the menu right after this - without a word the operator
+     would get no hint that the plate is theirs to raise (audit 2026-09-12). */
+  if (stopped) screenPlateNote("Raise the plate");
 }
 
 /**

--- a/src/Resume.ino
+++ b/src/Resume.ino
@@ -223,8 +223,13 @@ void resumeRaisePlateAndDiscard() {
   gfx2->setFont(&FreeSans8pt7b);
   gfx2->setTextColor(WHITE);
   gfx2->setTextSize(1);
-  gfx2->setCursor(8, 44);
-  gfx2->print("Raising plate...");
+  /* Two lines, both inside the 156 px frame: the plate is about to move on an
+     ESTIMATED height, so the operator is told to watch it and how to stop it
+     (V 2026-09-12). Widths against "Plate is at the top" = 119 px for 19 chars. */
+  gfx2->setCursor(8, 30);
+  gfx2->print("Raising plate.");
+  gfx2->setCursor(8, 56);
+  gfx2->print("Watch it - BACK stops");
 
   // Discard the checkpoint BEFORE moving: UP = "do not resume", so a power
   // loss (or watchdog reset) mid-raise must not re-prompt a resume with an
@@ -241,17 +246,30 @@ void resumeRaisePlateAndDiscard() {
   long liftSteps = (long)((Slow_Lift_Distance + Fast_Lift_Distance) * steps_mm);
   stepper.setMaxSpeed(Slow_Lift_Feedrate * steps_mm / 60);
   stepper.move(liftSteps);
-  while (stepper.distanceToGo() != 0) stepper.run();
+  /* BACK stops the move, the same as the manual jog (Motor.ino). Without it the
+     "watch it" on screen would be an empty word: the height under these moves is an
+     estimate, and only the operator can see the plate nearing the top (V 2026-09-12). */
+  bool stopped = false;
+  while (stepper.distanceToGo() != 0) {
+    stepper.run();
+    if (digitalRead(buttonBack) == LOW) { stopped = true; break; }
+  }
   delay(50);
 
-  // Then up to the pause-style park: +20mm over the checkpoint, clamped.
-  long maxSteps = (long)(max_height * steps_mm);
+  /* Then up to the pause-style park: +20mm over the checkpoint, clamped 6 mm BELOW
+     max_height. The checkpoint is an estimate kept low by up to the peel distance
+     (2-6 mm), and only 3 mm of Z travel exist above max_height (measured 2026-09-12),
+     so clamping to the full 68 mm could drive the plate into the top. */
+  long maxSteps = (long)((max_height - 6) * steps_mm);
   long target = resumePosSteps + (long)(20 * steps_mm);
   if (target > maxSteps) target = maxSteps;
-  if (target > stepper.currentPosition()) {
+  if (!stopped && target > stepper.currentPosition()) {
     stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60);
     stepper.moveTo(target);
-    while (stepper.distanceToGo() != 0) stepper.run();
+    while (stepper.distanceToGo() != 0) {
+      stepper.run();
+      if (digitalRead(buttonBack) == LOW) break;
+    }
   }
   stepper.disableOutputs();
   delay(200);

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -2860,6 +2860,12 @@ void loop() {
             }
             #endif
             Position_before_pause = stepper.currentPosition();
+            /* No resume across this lift (V 2026-09-12: if resuming could damage the
+               printer or the part, drop the record). During the 20-40 mm rise the card
+               still holds the lower cycle height; "Lift plate only" at the boot prompt
+               would then add 20 mm on top of the real height and could hit the top.
+               The exact 'P' record is written once the plate is parked. */
+            resumeClear();
             stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60);
             stepper.enableOutputs();
             /* Three cases, not two. The plain lift fits, or it is trimmed to the
@@ -2869,7 +2875,10 @@ void loop() {
                drive the plate DOWNWARDS, into the part, in the middle of a print
                (audit 09-05, same shape as manual_lift). */
             {
-              const long ceilingSteps = (long)(max_height * steps_mm);
+              /* After a power-loss resume the height is an estimate kept LOW by up to the
+                 peel distance (2-6 mm), so a pause near the top could lift the plate that
+                 far past 68 mm. Unhomed, the ceiling is 6 mm lower: 62 mm (V 2026-09-12). */
+              const long ceilingSteps = (long)((zHomed ? max_height : max_height - 6) * steps_mm);
               const long wanted = Position_before_pause + (long)(pauseLiftMm * steps_mm);
               if (wanted <= ceilingSteps)
                 stepper.move(pauseLiftMm * steps_mm);
@@ -3009,6 +3018,11 @@ void loop() {
               gfx2->fillRect(136, 52, 6, 16, 0x8410);
               gfx2->fillRect(146, 52, 6, 16, 0x8410);
               gfx2->drawRoundRect(128, 44, 32, 32, 3, 0x8410);
+              /* No resume across this travel either: the card says 'P' at the pause height
+                 while the plate is already on its way down, so a resume after a power cut
+                 here would drive the part into the FEP and the screen below it. The 'M'
+                 record is written again once the plate is down (V 2026-09-12). */
+              resumeClear();
               stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60);
               stepper.enableOutputs();
               stepper.moveTo(Position_before_pause);

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -2910,11 +2910,18 @@ void loop() {
             stepper.disableOutputs();
             delay(10); 
 
-            current_state = lowResinPauseNow ? 10 : 6;  // 10 = "Refill VAT" pause
             pauseLiftForResin = false;   // the lift is over; the parked state has its own text
+            /* Stop pressed while the plate was rising. The lift answers HTTP but reads no
+               buttons, so this is a web/MQTT/Connect stop: requestPrintStop() has already set
+               state 4 and cleared print_paused. Parking the pause on top of it showed "Paused"
+               with Resume live on the dashboard and the pause icons on the LCD for the whole
+               ~24 s final lift (and a resin pause would still send its Telegram) - measured
+               2026-09-11. A stopped print does not park: it stays "Canceling". */
+            bool lowResinNotifyPending = false;
+            if (!print_canceled) {
+            current_state = lowResinPauseNow ? 10 : 6;  // 10 = "Refill VAT" pause
             phaseWaitStage = "";   // laukimas baigesi - stovim, skaiciuoti nebera ko
-            bool lowResinNotifyPending = lowResinPauseNow;
-            lowResinPauseNow = false;
+            lowResinNotifyPending = lowResinPauseNow;
             saveVatRemaining();   // checkpoint at the pause point
             resumeCheckpoint('P');  // parked position is exact
             screen1111_state();
@@ -2923,6 +2930,8 @@ void loop() {
             gfx2->fillRect(146, 52, 6, 16, BLACK);   // both used to show at once (V 2026-09-10)
             gfx2->fillTriangle(136, 52, 136, 68, 152, 60, GREEN);
             screen1111DOWN();
+            }
+            lowResinPauseNow = false;
             #if ENABLE_NETWORK
             // Notify only after the checkpoint is saved and the pause UI is
             // drawn: on weak WiFi the blocking send can hold the loop for

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -3032,15 +3032,23 @@ void loop() {
               }
               stepper.disableOutputs();
               delay(10);
-              // Back at the post-lift height; the drop to the next layer
-              // follows - same uncertainty window as a normal peel cycle.
-              resumeCheckpointAt('M', Position_before_pause -
-                  (long)((Slow_Lift_Distance + Fast_Lift_Distance) * steps_mm));
-              gfx2->fillRect(136, 12, 16, 16, RED);
-              gfx2->fillRect(136, 52, 6, 16, YELLOW);
-              gfx2->fillRect(146, 52, 6, 16, YELLOW); 
-              gfx2->drawRoundRect(128, 44, 32, 32, 3, WHITE);
-              print_paused = false;    
+              /* A web/Connect Stop can land during this travel too (it answers HTTP but
+                 reads no buttons): requestPrintStop() sets state 4, clears print_paused and
+                 greys the icons. Redrawing the live icons on top of that showed active
+                 buttons over "Canceling..." for the whole final lift (audit 2026-09-11, the
+                 same shape as the pause-lift fix above). Only a resume that still stands
+                 gets its checkpoint and live icons back. */
+              if (print_paused) {
+                // Back at the post-lift height; the drop to the next layer
+                // follows - same uncertainty window as a normal peel cycle.
+                resumeCheckpointAt('M', Position_before_pause -
+                    (long)((Slow_Lift_Distance + Fast_Lift_Distance) * steps_mm));
+                gfx2->fillRect(136, 12, 16, 16, RED);
+                gfx2->fillRect(136, 52, 6, 16, YELLOW);
+                gfx2->fillRect(146, 52, 6, 16, YELLOW);
+                gfx2->drawRoundRect(128, 44, 32, 32, 3, WHITE);
+              }
+              print_paused = false;
               }       
             }                     
           }

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -2911,27 +2911,27 @@ void loop() {
             delay(10); 
 
             pauseLiftForResin = false;   // the lift is over; the parked state has its own text
-            /* Stop pressed while the plate was rising. The lift answers HTTP but reads no
-               buttons, so this is a web/MQTT/Connect stop: requestPrintStop() has already set
-               state 4 and cleared print_paused. Parking the pause on top of it showed "Paused"
-               with Resume live on the dashboard and the pause icons on the LCD for the whole
-               ~24 s final lift (and a resin pause would still send its Telegram) - measured
-               2026-09-11. A stopped print does not park: it stays "Canceling". */
+            /* Park only if the pause still stands. The lift answers HTTP but reads no
+               buttons, so a web/Connect Stop can land mid-lift: requestPrintStop() sets state 4
+               and clears print_paused. Parking on top of it showed "Paused" with Resume live on
+               the dashboard and the pause icons on the LCD for the whole ~24 s final lift (and a
+               resin pause would still send its Telegram) - measured 2026-09-11. Checked as
+               print_paused, not print_canceled: that is the flag the loop below waits on, so a
+               parked pause can never be left without its loop. */
             bool lowResinNotifyPending = false;
-            if (!print_canceled) {
-            current_state = lowResinPauseNow ? 10 : 6;  // 10 = "Refill VAT" pause
-            phaseWaitStage = "";   // laukimas baigesi - stovim, skaiciuoti nebera ko
-            lowResinNotifyPending = lowResinPauseNow;
-            saveVatRemaining();   // checkpoint at the pause point
-            resumeCheckpoint('P');  // parked position is exact
-            screen1111_state();
-            gfx2->fillRect(136, 12, 16, 16, RED);
-            gfx2->fillRect(136, 52, 6, 16, BLACK);   // wipe the pause bars before the play triangle -
-            gfx2->fillRect(146, 52, 6, 16, BLACK);   // both used to show at once (V 2026-09-10)
-            gfx2->fillTriangle(136, 52, 136, 68, 152, 60, GREEN);
-            screen1111DOWN();
+            if (print_paused) {
+              current_state = lowResinPauseNow ? 10 : 6;  // 10 = "Refill VAT" pause
+              phaseWaitStage = "";   // laukimas baigesi - stovim, skaiciuoti nebera ko
+              lowResinNotifyPending = lowResinPauseNow;
+              saveVatRemaining();   // checkpoint at the pause point
+              resumeCheckpoint('P');  // parked position is exact
+              screen1111_state();
+              gfx2->fillRect(136, 12, 16, 16, RED);
+              gfx2->fillRect(136, 52, 6, 16, BLACK);   // wipe the pause bars before the play triangle -
+              gfx2->fillRect(146, 52, 6, 16, BLACK);   // both used to show at once (V 2026-09-10)
+              gfx2->fillTriangle(136, 52, 136, 68, 152, 60, GREEN);
+              screen1111DOWN();
             }
-            lowResinPauseNow = false;
             #if ENABLE_NETWORK
             // Notify only after the checkpoint is saved and the pause UI is
             // drawn: on weak WiFi the blocking send can hold the loop for

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -3032,17 +3032,21 @@ void loop() {
               }
               stepper.disableOutputs();
               delay(10);
+              // Back at the post-lift height; the drop to the next layer
+              // follows - same uncertainty window as a normal peel cycle.
+              // Written even when a Stop landed during the travel: the plate IS down
+              // here now, and the pause's 'P' record would put it ~20 mm higher for a
+              // power-loss recovery - which would then drive it into the part (audit
+              // 2026-09-11). Outside the condition below on purpose.
+              resumeCheckpointAt('M', Position_before_pause -
+                  (long)((Slow_Lift_Distance + Fast_Lift_Distance) * steps_mm));
               /* A web/Connect Stop can land during this travel too (it answers HTTP but
                  reads no buttons): requestPrintStop() sets state 4, clears print_paused and
                  greys the icons. Redrawing the live icons on top of that showed active
                  buttons over "Canceling..." for the whole final lift (audit 2026-09-11, the
                  same shape as the pause-lift fix above). Only a resume that still stands
-                 gets its checkpoint and live icons back. */
+                 gets its live icons back. */
               if (print_paused) {
-                // Back at the post-lift height; the drop to the next layer
-                // follows - same uncertainty window as a normal peel cycle.
-                resumeCheckpointAt('M', Position_before_pause -
-                    (long)((Slow_Lift_Distance + Fast_Lift_Distance) * steps_mm));
                 gfx2->fillRect(136, 12, 16, 16, RED);
                 gfx2->fillRect(136, 52, 6, 16, YELLOW);
                 gfx2->fillRect(146, 52, 6, 16, YELLOW);

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -3009,16 +3009,6 @@ void loop() {
               gfx2->fillRect(136, 52, 6, 16, 0x8410);
               gfx2->fillRect(146, 52, 6, 16, 0x8410);
               gfx2->drawRoundRect(128, 44, 32, 32, 3, 0x8410);
-              /* The plate is about to travel back down the pause lift (pauseLiftMm, 20-40 mm,
-                 clamped to the ceiling) while the record on the card still
-                 says 'P' at the pause height. A power loss during the travel would relabel
-                 the plate as that height and drive it down into the part. Write the cycle
-                 base as 'M' first: it is at or below the plate for the whole travel, so a
-                 recovery can only err upward (a gap, not a crash) - the invariant the peel
-                 moves keep (Resume.ino). The same value is written again after the travel.
-                 (Audit 2026-09-11; the 'P' window dates from the resume feature.) */
-              resumeCheckpointAt('M', Position_before_pause -
-                  (long)((Slow_Lift_Distance + Fast_Lift_Distance) * steps_mm));
               stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60);
               stepper.enableOutputs();
               stepper.moveTo(Position_before_pause);

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -3009,7 +3009,8 @@ void loop() {
               gfx2->fillRect(136, 52, 6, 16, 0x8410);
               gfx2->fillRect(146, 52, 6, 16, 0x8410);
               gfx2->drawRoundRect(128, 44, 32, 32, 3, 0x8410);
-              /* The plate is about to travel ~20 mm down while the record on the card still
+              /* The plate is about to travel back down the pause lift (pauseLiftMm, 20-40 mm,
+                 clamped to the ceiling) while the record on the card still
                  says 'P' at the pause height. A power loss during the travel would relabel
                  the plate as that height and drive it down into the part. Write the cycle
                  base as 'M' first: it is at or below the plate for the whole travel, so a

--- a/src/TinyMaker.ino
+++ b/src/TinyMaker.ino
@@ -2989,7 +2989,12 @@ void loop() {
               print_canceled = true;
               publishStopEstimate(wasPhase);
               print_paused = false;
-              }  
+              // A web Resume that arrived in this same pass must not win over the Stop just
+              // confirmed here: requestPrintStop() clears it on the web path, this button
+              // path did not, so the branch below would still start the travel (audit
+              // 2026-09-11).
+              webResumePrint = false;
+              }
               if ((Duration2 >= 500 && digitalRead(buttonOK) == LOW && screen == 11113) || webResumePrint){
               /* On the printer the confirm box IS the refill acknowledgement: during a
                  resin pause it asks "VAT filled full?", and the paused screen has no other
@@ -3004,6 +3009,15 @@ void loop() {
               gfx2->fillRect(136, 52, 6, 16, 0x8410);
               gfx2->fillRect(146, 52, 6, 16, 0x8410);
               gfx2->drawRoundRect(128, 44, 32, 32, 3, 0x8410);
+              /* The plate is about to travel ~20 mm down while the record on the card still
+                 says 'P' at the pause height. A power loss during the travel would relabel
+                 the plate as that height and drive it down into the part. Write the cycle
+                 base as 'M' first: it is at or below the plate for the whole travel, so a
+                 recovery can only err upward (a gap, not a crash) - the invariant the peel
+                 moves keep (Resume.ino). The same value is written again after the travel.
+                 (Audit 2026-09-11; the 'P' window dates from the resume feature.) */
+              resumeCheckpointAt('M', Position_before_pause -
+                  (long)((Slow_Lift_Distance + Fast_Lift_Distance) * steps_mm));
               stepper.setMaxSpeed(Fast_Lift_Feedrate * steps_mm / 60);
               stepper.enableOutputs();
               stepper.moveTo(Position_before_pause);


### PR DESCRIPTION
**Firmware - manual merge only, no auto-merge.** Built, audited and tested on the printer (details below).

Three plate moves answer HTTP but read no buttons: the lift into a pause, the travel back down after Resume, and the final lift at the end of a print. A dashboard (or Connect) Stop is accepted during any of them, and a power cut during any of them leaves a saved resume point that no longer matches where the plate is. This PR closes both, and one hardware fact found on the way shaped the rest: **above the 68 mm software limit there are only 3 mm of physical Z travel** (measured with a ruler, 2026-09-12).

## 1. Stop during the pause lift showed "Paused"

When the lift ended, the pause was parked anyway (`current_state = 6/10`, pause icons on the LCD, a resume checkpoint, and for a resin pause the Telegram refill message). The print ended correctly, but for the ~24 s final lift `/api/status` said `Paused` with `canResume=true` and the LCD band said "Paused".

**Fix:** park only `if (print_paused)`. `requestPrintStop()` clears that flag, so a stopped print stays "Canceling". Normal and resin pauses park exactly as before.

## 2. Stop during the resume travel redrew live buttons

After the travel back down, the live Stop/Pause icons were redrawn over the grey ones `requestPrintStop()` had drawn, so the LCD showed active buttons next to "Canceling..." for the final lift.

**Fix:** redraw them only `if (print_paused)`.

## 3. A resumed print drove the plate into the top of the Z travel

Found on the printer: a Stop after a power-loss resume ended with the plate hitting the top and the motor stalling. Recovery never homes and keeps the height estimate deliberately low, while the final lift moved to the absolute `max_height` - about 20 mm too high, against 3 mm of reserve.

**Fix:** `lift_finished_print()` does nothing while unhomed. The last layer's peel has already run, so the plate stays where it is and the LCD says "Raise the plate" (~3.5 s, HTTP still served every 200 ms). Normal prints home first and keep their lift. In a resumed print the pause lift ceiling is 62 mm instead of 68 mm, to leave room for the small height error.

## 4. No resume across a move that could damage something

Owner's rule: if resuming after a power cut during a move could damage the printer or the part, there is no resume for that move. The saved point is dropped before the pause lift, before the travel down after Resume, and before the final lift; it is written again when the plate stops. A cut while parked in a pause, or during the layer moves, still resumes exactly as before.

This also removes the worst case found while reviewing: a cut during the travel down left the pause's `'P'` height on the card, and a Resume from there would have driven the part into the FEP and the screen below it.

## 5. "Lift plate only" at the boot prompt

That lift also ran to the absolute 68 mm from the estimated height, so with a tall print (plate above ~48 mm) and a cut during a layer move it could overshoot by the peel distance - more than the 3 mm that exist.

**Fix:** the park target is clamped 6 mm below `max_height`, both of its moves stop on BACK, and the screen says "Raising plate." / "Watch it - BACK stops". Stopping with BACK shows "Raise the plate", since the plate then stays wherever it stopped.

## 6. Small ones

- A printer-button Stop now clears `webResumePrint`, so a web Resume landing in the same loop pass cannot start the travel over the Stop.

## Checks

- `pio run -e tinymaker`: SUCCESS, Flash 76.5 %, RAM 31.3 % (`e64da93`).
- `firmware-auditor` after every step. It caught two real regressions on the way: a checkpoint left under the same condition as the icons (would have put the plate ~20 mm too high for a power-loss recovery), and a screen line running 3 px off the 160 px display. Both fixed here.
- On the printer, dry run, status recorded from the dashboard every 200 ms:
  - **Pause lift, before** (`6219626`): `pauseLift` -> Stop -> `Canceling` -> **`Paused`, canResume=true (24 s)** -> `Idle`
  - **Pause lift, after** (`3f2c79b`): `pauseLift` -> Stop -> `Canceling` -> `Canceling/stopLift` -> `Idle`
  - **Resume travel, after** (`648563b`): `Paused` -> `Resuming` -> Stop 4 s in -> `Canceling` all the way -> `Idle`; the LCD icons stayed grey (seen on the printer).
  - **Power cut during the resume travel** (`27412eb`, by hand): resume prompt, Resume, the plate rose a few mm and came back no lower than where it stopped.
  - **Normal print still lifts** (`e421b9b`): `Test4min` -> "Raising plate" -> plate 5.3 mm -> 23.3 mm -> `Idle`.
- Not yet exercised on the printer: the no-lift-after-resume path, the dropped records, the 62 mm ceilings and the "Lift plate only" path. They are audited and compiled; each needs another power cut to reach.

## Not in this PR (pre-existing)

- `Slow_Lift_Distance` / `Fast_Lift_Distance` are read from EEPROM without clamping (the backup path clamps them), so a corrupted byte could produce an unreal peel distance.
- Dry run turned itself off across a power cut once (UV ran for ~63 s in one resumed test print). No automatic code path was found; likely switched off by hand. Being watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
