### PR TITLE
gitignore: bytecode and test output stop being offered as source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ scripts/__pycache__/
 scripts/dev/local/
 scripts/dev/index.html
 scripts/dev/local-links.json
+
+# Python bytecode: build output, not source
+__pycache__/
+
+# Test output (generated SVG previews), not source
+scripts/dev/test-out/


### PR DESCRIPTION
Two `.gitignore` lines that lived only on the slicer branch. Brought over while unifying `slcr/dev` into `main`; the rest of that branch is archived under `archive/slcr-dev-2026-09-11`, not merged.

- `__pycache__/` - repo-wide, not per directory. A `.pyc` was tracked once under `wasm/`, and `scripts/` was heading the same way.
- `scripts/dev/test-out/` - SVG previews the slicer tests render.

Main's own entries are untouched. No source file changes, so nothing to test on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)