### PR TITLE
docs: the slicer side owns the engine source, not files that no longer exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Pultas gzip'inamas ir įdedamas į flash'ą. Nuo 0.17 **slicerio dalys gyvena
 **Kodėl:** prie projekto dirba dvi sesijos - viena prie printerio, kita prie
 slicerio - ir abi rašė į tą patį failą iš skirtingų šakų. Riba dabar tokia:
 printerio pusė valdo `dashboard.html` ir firmware, slicerio pusė - `web/parts/*`
-ir `web/lib/slicer*.js`. Kelios vietos, kur sliceris tikrai lenda į pulto vidų
+ir `wasm/` (variklio šaltinis). Kelios vietos, kur sliceris tikrai lenda į pulto vidų
 (3D vaizdo perdanga, `applyStatus` kabliukai), lieka pulte kaip pavieniai
 iškvietimai; jas keičia printerio pusė.
 


### PR DESCRIPTION
One line in `CLAUDE.md`. The session boundary still handed the slicer `web/lib/slicer*.js`, but those files are no longer on main - the JS slicer was archived under `archive/slcr-dev-2026-09-11` when the slicer branches were unified. What the slicer side owns today is `web/parts/*` and `wasm/`.

No rule changes: the same two sessions own the same two halves.

**Not set to auto-merge.** `CLAUDE.md` is the shared file both sessions read, so it is merged only on V's word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)