### PR TITLE
sessions: the printer area lives on main now, not the 0.17 integration branch

### DIFF
--- a/scripts/dev/sritys.json
+++ b/scripts/dev/sritys.json
@@ -13,11 +13,11 @@
     {
       "sritis": "Printeris",
       "priesdelis": "prnt/",
-      "saka": "0.17/slicer-merge",
+      "saka": "main",
       "katalogas": "Documents/PlatformIO/Projects/TinyMakerWiFi",
       "repo": "TinyMakerWifi",
       "uz_ka": "firmware, pultas, dokumentacija, leidyba",
-      "pastaba": "0.17 integracine saka - joje VISKAS, kas ruosiama testams. Po isleidimo darbas pereis i prnt/0.18-*"
+      "pastaba": "2026-09-12: 0.17 isleista (0.17.0 ir 0.17.1 beta kanale), tad integracines sakos nebereikia - namu saka yra main. Funkciniai darbai daromi prnt/* sakose ir merginami i main; leidyba kertama TIK is main. Artimiausia laukiama laida - 0.17.2 (0.17.x linija), 0.18 neplanuojama. Sena 0.17/slicer-merge palikta gulėti: jos turinys visas main viduje, bet ant jos tebestovi V pagrindinis medis"
     },
     {
       "sritis": "Sliceris",


### PR DESCRIPTION
`scripts/dev/sritys.json` printerio eilutė tebesakė, kad namų šaka yra `0.17/slicer-merge`, o pastaba žadėjo, kad „po išleidimo darbas pereis į `prnt/0.18-*`".

0.17 jau išleista - **du kartus** (0.17.0 ir 0.17.1, beta kanale). Tad tas įrašas melavo abiem galais: integracinės šakos nebereikia, o 0.18 apskritai neplanuojama - kita laukiama laida yra **0.17.2**.

Kodėl tai svarbu: `kur_esu.py` šitą failą skaito ir pagal jį sprendžia, ar sesija atsistojo teisingoje vietoje. Pasenęs įrašas reiškia, kad kiekviena nauja sesija gauna klaidingą atsakymą - lygiai tai, nuo ko failas ir turėjo saugoti (jo paties `_doc` sako: „pasenęs įrašas išsiduoda pats, o ne po dviejų savaičių").

Kas pakeista:
- `saka`: `0.17/slicer-merge` → `main` (leidyba kertama tik iš `main`, funkciniai darbai - `prnt/*` šakose su PR).
- `pastaba`: paaiškinta, kad 0.17 išleista, kad kita laida yra 0.17.2, ir kad senoji šaka palikta gulėti, nes ant jos tebestovi V pagrindinis medis.

Slicerio eilutė jau buvo sutvarkyta PR #132 - jos neliečiau.

⚠️ Laukiamas šalutinis poveikis: nuo šiol `kur_esu.py` **perspės**, kai sesija atsistos V pagrindiniame kataloge, nes tas medis tebestovi ant `0.17/slicer-merge`. Taip ir turi būti - tai tikras neatitikimas, o ne klaidingas pavojaus signalas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
