### PR TITLE
sessions: the area table says where the messaging address comes from

### DIFF
--- a/scripts/dev/sritys.json
+++ b/scripts/dev/sritys.json
@@ -6,7 +6,11 @@
     "tad pasenes irasas issiduoda pats, o ne po dvieju savaiciu.",
     "Laukas 'saka' = NAMU saka, kur srities darbas galiausiai sugula. Sesija gali teisetai",
     "sedeti kitoje (laikinoje, antroje tos pacios srities, bendroje main/experimental) -",
-    "tai ne pasenimas, ir kur_esu.py tokiais atvejais tyli."
+    "tai ne pasenimas, ir kur_esu.py tokiais atvejais tyli.",
+    "Adresas zinutems (SendMessage) cia NERASOMAS samoningai: jis gimsta is darbo",
+    "katalogo vardo, per sesijos pervadinima NESIKEICIA ir mirsta kartu su langu.",
+    "Sesijos ANTRASTE (TinyMakerPrint, TinyMakerSlicer) adresu NEVEIKIA - gyva adresa",
+    "imti TIK is ListAgents pirmos eilutes. Ismatuota 2026-09-12."
   ],
   "_atnaujinta": "2026-09-12",
   "sritys": [


### PR DESCRIPTION
Four lines in the `_doc` block of `scripts/dev/sritys.json`.

Measured today while two sessions could not reach each other: the address `SendMessage` needs is minted from the working directory name, does not follow `set_session_title`, and dies with the window. A renamed session keeps its old address - that is what cost us a failed send.

Only the rule is written down, not the values: an address list would go stale overnight, and this file is the canon for long-lived facts. The live source is `ListAgents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)