### PR TITLE
slicer: the fit verdict comes after the supports exist, not before it

### DIFF
--- a/wasm/slicer-wasm-worker.js
+++ b/wasm/slicer-wasm-worker.js
@@ -107,6 +107,45 @@ function pjaustymas(pos, sluoksnis, medis, pakelta, perziuros) {
   return { d: d, info: info, sl1: sl1, preview: preview, previewInfo: previewInfo };
 }
 
+/* FIT-real: TIKRAS pedsakas, kai atramos jau pastatytos.
+ *
+ * Iki siol „telpa ar ne" buvo sprendziama PRIES pjaustyma, is blogiausio atvejo:
+ * nuo kiekvienos puses atimta po 3,1 mm (atramos pedos spindulys 1,5 + pado
+ * apvadas 1,6), ir detalei likdavo 68 % ploksces. Bet tiek vietos reikia tik ten,
+ * kur atrama tikrai stovi - dazniausiai ne aplink visa siluetta.
+ *
+ * Cia matuojam, kiek vietos uzima tai, kas REALIAI pastatyta: modelis, atramos
+ * ir padas. Skaitom pacius STL baitus is variklio failu sistemos - tie patys
+ * failai, kuriuos atiduoda `geometrija()`, tik ju niekur neperduodam: didelio
+ * modelio atramos yra keliolika megabaitu, o mums reikia keturiu skaiciu.
+ *
+ * Koordinates - variklio, t. y. ploksces CENTRAS yra nulis.
+ */
+function pedsakasXY() {
+  let x0 = Infinity, x1 = -Infinity, y0 = Infinity, y1 = -Infinity, rasta = false;
+  for (const kelias of ['/out_model.stl', '/out_supports.stl', '/out_pad.stl']) {
+    let b;
+    try { b = M.FS.readFile(kelias); } catch (e) { continue; }
+    if (!b || b.length < 84) continue;
+    const dv = new DataView(b.buffer, b.byteOffset, b.byteLength);
+    const n = dv.getUint32(80, true);
+    if (84 + n * 50 > b.length) continue;          // sugadintas ar nepilnas STL
+    for (let t = 0; t < n; t++) {
+      const p0 = 84 + t * 50 + 12;                 // normale praleidziama
+      for (let v = 0; v < 3; v++) {
+        const x = dv.getFloat32(p0 + v * 12, true);
+        const y = dv.getFloat32(p0 + v * 12 + 4, true);
+        if (x < x0) x0 = x;
+        if (x > x1) x1 = x;
+        if (y < y0) y0 = y;
+        if (y > y1) y1 = y;
+      }
+    }
+    rasta = true;
+  }
+  return rasta ? { x0: x0, x1: x1, y0: y0, y1: y1 } : null;
+}
+
 /* Tilto `praneskEiga` kviecia butent sita. */
 self.slaProgress = function (etapas, proc) {
   self.postMessage({ tipas: 'eiga', id: dabartinisId, etapas: etapas, proc: proc });
@@ -199,7 +238,10 @@ self.onmessage = async function (ev) {
       const perduoti = r.preview ? [r.sl1.buffer, r.preview] : [r.sl1.buffer];
       self.postMessage({ tipas: 'atsakymas', id: z.id, duomenys: r.d, sl1info: r.info,
                          sl1: r.sl1.buffer, preview: r.preview, previewInfo: r.previewInfo,
-                         auto: auto },
+                         auto: auto,
+                         /* FIT-real: matuojam PO #116 automatikos, nes pakelta detale
+                            turi kitas atramas ir kitoki pedsaka. */
+                         pedsakas: pedsakasXY() },
                        perduoti);
 
     } else if (z.tipas === 'pakrypimas') {

--- a/wasm/slicer-wasm-worker.js
+++ b/wasm/slicer-wasm-worker.js
@@ -104,7 +104,13 @@ function pjaustymas(pos, sluoksnis, medis, pakelta, perziuros) {
     }
   } catch (e) { previewInfo = { klaida: String(e && e.message || e) }; }
 
-  return { d: d, info: info, sl1: sl1, preview: preview, previewInfo: previewInfo };
+  /* Pedsakas imamas CIA, o ne gale: `/out_*.stl` priklauso PASKUTINIAM ejimui,
+     o #116 automatika gali antra ejima atmesti ir grazinti pirmojo rezultata.
+     Tada gale isMatuotume pakeltos detales atramas, nors spausdinamas ploksScias
+     variantas - ir pilnai telpantis daiktas butu sumazintas be priezasties
+     (printerio sesijos auditas, 09-12). */
+  return { d: d, info: info, sl1: sl1, preview: preview, previewInfo: previewInfo,
+           pedsakas: pedsakasXY() };
 }
 
 /* FIT-real: TIKRAS pedsakas, kai atramos jau pastatytos.
@@ -122,28 +128,38 @@ function pjaustymas(pos, sluoksnis, medis, pakelta, perziuros) {
  * Koordinates - variklio, t. y. ploksces CENTRAS yra nulis.
  */
 function pedsakasXY() {
-  let x0 = Infinity, x1 = -Infinity, y0 = Infinity, y1 = -Infinity, rasta = false;
-  for (const kelias of ['/out_model.stl', '/out_supports.stl', '/out_pad.stl']) {
-    let b;
-    try { b = M.FS.readFile(kelias); } catch (e) { continue; }
-    if (!b || b.length < 84) continue;
-    const dv = new DataView(b.buffer, b.byteOffset, b.byteLength);
-    const n = dv.getUint32(80, true);
-    if (84 + n * 50 > b.length) continue;          // sugadintas ar nepilnas STL
-    for (let t = 0; t < n; t++) {
-      const p0 = 84 + t * 50 + 12;                 // normale praleidziama
-      for (let v = 0; v < 3; v++) {
-        const x = dv.getFloat32(p0 + v * 12, true);
-        const y = dv.getFloat32(p0 + v * 12 + 4, true);
-        if (x < x0) x0 = x;
-        if (x > x1) x1 = x;
-        if (y < y0) y0 = y;
-        if (y > y1) y1 = y;
+  try {
+    let x0 = Infinity, x1 = -Infinity, y0 = Infinity, y1 = -Infinity, rasta = false;
+    for (const kelias of ['/out_model.stl', '/out_supports.stl', '/out_pad.stl']) {
+      let b;
+      try { b = M.FS.readFile(kelias); } catch (e) { continue; }
+      if (!b || b.length < 84) continue;
+      const dv = new DataView(b.buffer, b.byteOffset, b.byteLength);
+      const n = dv.getUint32(80, true);
+      if (!n) continue;                            // tuscias STL - ne matavimas
+      if (84 + n * 50 > b.length) continue;        // sugadintas ar nepilnas
+      for (let t = 0; t < n; t++) {
+        const p0 = 84 + t * 50 + 12;               // normale praleidziama
+        for (let v = 0; v < 3; v++) {
+          const x = dv.getFloat32(p0 + v * 12, true);
+          const y = dv.getFloat32(p0 + v * 12 + 4, true);
+          if (x < x0) x0 = x;
+          if (x > x1) x1 = x;
+          if (y < y0) y0 = y;
+          if (y > y1) y1 = y;
+        }
       }
+      rasta = true;
     }
-    rasta = true;
+    /* Be `isFinite` tuscias rinkinys duotu Infinity, o is jo - mastelis 0,05:
+       modelis butu sutrauktas iki 5 % vietoj „nezinau" (auditas 09-12). */
+    if (!rasta || !isFinite(x0) || !isFinite(y0)) return null;
+    return { x0: x0, x1: x1, y0: y0, y1: y1 };
+  } catch (e) {
+    /* Pedsakas yra priedas, o ne rezultatas: klaida cia neturi nuzudyti jau
+       pagaminto .sl1. Be pedsako adapteris tiesiog nieko nemazina. */
+    return null;
   }
-  return rasta ? { x0: x0, x1: x1, y0: y0, y1: y1 } : null;
 }
 
 /* Tilto `praneskEiga` kviecia butent sita. */
@@ -239,9 +255,8 @@ self.onmessage = async function (ev) {
       self.postMessage({ tipas: 'atsakymas', id: z.id, duomenys: r.d, sl1info: r.info,
                          sl1: r.sl1.buffer, preview: r.preview, previewInfo: r.previewInfo,
                          auto: auto,
-                         /* FIT-real: matuojam PO #116 automatikos, nes pakelta detale
-                            turi kitas atramas ir kitoki pedsaka. */
-                         pedsakas: pedsakasXY() },
+                         /* FIT-real: imam TO ejimo pedsaka, kuris ir grazinamas. */
+                         pedsakas: r.pedsakas || null },
                        perduoti);
 
     } else if (z.tipas === 'pakrypimas') {

--- a/wasm/slicer-wasm.js
+++ b/wasm/slicer-wasm.js
@@ -209,6 +209,35 @@ const ETAPO_DALIS = {
   'gaminami sluoksniai': 0.80,
 };
 
+/* Atsarga nuo ploksces krasto, mm.
+ *
+ * NE dėl ekrano: 2026-09-12 atspausdintos kopeteles (`T93-remeliai`) parode, kad
+ * ekranas kietina iki pat 0,51 mm nuo svieciamo ploto krasto - visi penki remeliai
+ * iseejo. Riba diktuoja MECHANIKA: ploksce tvirtinama su laisvumu i sonus, tad
+ * detale gali atsistoti apie milimetra nuo ten, kur jos tikimasi (V matavimas).
+ *
+ * Anksciau vietoj sito buvo 3,1 mm, atimami PRIES pjaustyma nuo kiekvienos puses
+ * (atramos pedos spindulys 1,5 + pado apvadas 1,6). Ta atsarga reikalinga tik ten,
+ * kur atrama tikrai stovi, o buvo taikoma visam modeliui - ir detalei likdavo
+ * 68 % ploksces. Dabar tikras pedsakas matuojamas PO atramu (zr. zemiau). */
+const KRASTO_ATSARGA_MM = 1.0;
+
+/** Kiek reiketu sumazinti, kad pastatytas daiktas tilptu. 1 - telpa. */
+function reikiamasMastelis(pedsakas) {
+  if (!pedsakas) return 1;
+  /* Variklio nulis yra ploksces CENTRAS, o mastelis keiciamas apie ta pati nuli,
+     tad riboja didziausias nuokrypis i bet kuria puse, ne plotis. */
+  const ax = Math.max(Math.abs(pedsakas.x0), Math.abs(pedsakas.x1));
+  const ay = Math.max(Math.abs(pedsakas.y0), Math.abs(pedsakas.y1));
+  const ribaX = PLATE.x / 2 - KRASTO_ATSARGA_MM;
+  const ribaY = PLATE.y / 2 - KRASTO_ATSARGA_MM;
+  if (ax <= ribaX && ay <= ribaY) return 1;
+  const s = Math.min(ax > 0 ? ribaX / ax : 1, ay > 0 ? ribaY / ay : 1);
+  /* Apvalinam ZEMYN iki desimtosios procento: apvalinus i virsu daiktas vel
+     nebetilptu, ir antras ejimas butu veltui. */
+  return Math.max(0.05, Math.floor(s * 1000) / 1000);
+}
+
 /**
  * Suslicina jau pastatyta modeli.
  *
@@ -250,6 +279,30 @@ export async function slice(pos, opts, onProgress) {
                  galutine < 0.78 ? 'scan' : 'draw', z.etapas);
     });
 
+  /* FIT-real: ar tilpo, sprendziam CIA - kai atramos ir padas jau pastatyti, o
+     ne is anksto, is blogiausio atvejo. Jei pedsakas isleida uz ploksces,
+     perpjaunam sumazinta TIEK, kiek realiai truko, ir pasakom kodel. Antro rato
+     nebedarom (`_fitAntras`): naujas mastelis skaiciuotas is tikru ribu, o
+     begalinis mazinimas butu blogiau uz viena kartą per daug. */
+  if (!o._fitAntras) {
+    const mastelis = reikiamasMastelis(r.pedsakas);
+    if (mastelis < 1) {
+      const maz = new Float32Array(pos.length);
+      for (let i = 0; i < pos.length; i++) maz[i] = pos[i] * mastelis;
+      const antras = await slice(maz, Object.assign({}, o, { _fitAntras: true }), onProgress);
+      antras.sumazinta = {
+        mastelis: mastelis,
+        proc: Math.round((1 - mastelis) * 1000) / 10,
+        pedsakas: r.pedsakas,
+        /* Zinute pultui - viena eilute, be lango. Skaicius svarbus: is jo zmogus
+           mato, ar tai plauko storis, ar rimtas mazinimas. */
+        tekstas: 'Scaled down ' + (Math.round((1 - mastelis) * 1000) / 10).toFixed(1)
+                 + '% - the supports reached past the plate.'
+      };
+      return antras;
+    }
+  }
+
   const d = r.duomenys;
 
   /* .sl1 yra ZIP - is jo pasiimam PNG sluoksnius perziurai. Naršykle moka
@@ -289,6 +342,9 @@ export async function slice(pos, opts, onProgress) {
        plokstes. Naudotojui rodomas skaicius turi sutapti su tuo, ka gaus
        printeris (Terry: vidinis 340, faile 334). */
     layers: (r.sl1info && r.sl1info.sluoksniu) || d.sluoksniu,
+    /* Tikras pedsakas mm, ploksces centras - nulis. Pultui reikia, kad galetu
+       parodyti, kiek vietos liko, ir kad `FIT-real` butu patikrinamas is issores. */
+    pedsakas: r.pedsakas || null,
     rawMl: d.turis.viso_ml,
     supports: {
       /* #116: `tasku` yra SEJOS taskai - vietos, kurioms atramu galetu reiketi.

--- a/wasm/slicer-wasm.js
+++ b/wasm/slicer-wasm.js
@@ -287,17 +287,36 @@ export async function slice(pos, opts, onProgress) {
   if (!o._fitAntras) {
     const mastelis = reikiamasMastelis(r.pedsakas);
     if (mastelis < 1) {
+      /* Pirmo ejimo vaisiu nebereikia, o jie dideli: peržiūra ~24 MB (160 kadru
+         po du 320x240 zemelapius) plius .sl1. Be sito rekursijos metu atmintyje
+         guletu dvi perziuros, du .sl1 ir du tinkleliai - telefone kortele
+         nulustu be jokio paaiskinimo (auditas 09-12). */
+      r.preview = null;
+      r.sl1 = null;
+      if (onProgress) onProgress(0, 1000, 'scan', 'per didelis - pjaunam is naujo');
       const maz = new Float32Array(pos.length);
       for (let i = 0; i < pos.length; i++) maz[i] = pos[i] * mastelis;
       const antras = await slice(maz, Object.assign({}, o, { _fitAntras: true }), onProgress);
+      const proc = Math.round((1 - mastelis) * 1000) / 10;
+      /* Ar antras ejimas TIKRAI tilpo. Mastelis skaiciuotas taip, tarsi pedsakas
+         mazetu proporcingai, bet atramos peda (1,5 mm) ir pado apvadas (1,6 mm)
+         yra pastovus milimetrai, o sumazintam modeliui atramos sejamos is naujo -
+         tad naujas pedsakas nera s * senasis. Antro ejimo matavima jau turim
+         nemokamai; jei vis tiek islenda, sakom tai garsiai, o ne tylime
+         (printerio sesijos auditas, 09-12). */
+      const liko = reikiamasMastelis(antras.pedsakas);
       antras.sumazinta = {
         mastelis: mastelis,
-        proc: Math.round((1 - mastelis) * 1000) / 10,
+        proc: proc,
         pedsakas: r.pedsakas,
+        pedsakasPo: antras.pedsakas || null,
+        telpa: liko >= 1,
         /* Zinute pultui - viena eilute, be lango. Skaicius svarbus: is jo zmogus
            mato, ar tai plauko storis, ar rimtas mazinimas. */
-        tekstas: 'Scaled down ' + (Math.round((1 - mastelis) * 1000) / 10).toFixed(1)
-                 + '% - the supports reached past the plate.'
+        tekstas: liko >= 1
+          ? ('Scaled down ' + proc.toFixed(1) + '% - the supports reached past the plate.')
+          : ('Scaled down ' + proc.toFixed(1) + '% - the supports reached past the plate, '
+             + 'and they still do. Scale the model down by hand before printing.')
       };
       return antras;
     }

--- a/web/lib/slicer.js
+++ b/web/lib/slicer.js
@@ -161,7 +161,13 @@ export function place(pos, tr) {
    krastu, o stulpas lieka stoveti ant nieko (V pastebejimas, 08-19).
    `fitCheck(size, 0)` - sazininga isimtis tam, kas nori spausdinti iki pat
    krastu: tada atramas i vidu traukia XY krasto taisykle (slicer2). */
-let FIT_MARGIN_MM = 3.1;
+/* 2026-09-12: buvo 3,1 mm (atramos pedos spindulys 1,5 + pado apvadas 1,6),
+   atimami PRIES pjaustyma nuo kiekvienos puses - detalei likdavo 68 % ploksces.
+   Nuo `FIT-real` tikras pedsakas matuojamas PO atramu (`slicer-wasm.js`), tad cia
+   liko tik greitas preliminarus filtras, o jo skaiciu diktuoja MECHANIKA: ploksce
+   tvirtinama su laisvumu i sonus (~1 mm, V matavimas). Kad ekranas kietina iki pat
+   0,5 mm nuo krasto, parode `T93-remeliai` spaudinys. */
+let FIT_MARGIN_MM = 1.0;
 /** Atsarga atramoms aplink modeli, mm. `0` - modelis gali uzimti visa plokste
  *  (tada atramas i vidu traukia XY krasto taisykle). Laboratorijai butinas
  *  nulis: PrusaSlicer etalonas pjausto 100 % dydzio, ir mazinant musu modeli


### PR DESCRIPTION
`FIT-real`, plus the margin half of `FIT-edge`. Module only - no firmware, and nothing reaches anyone until the module is published and installed.

**What was wrong.** The fit decision happened before slicing, from the worst case: 3.1 mm off every side (support foot 1.5 + pad rim 1.6). That is the room a support needs *where one actually stands*, but it was charged to the whole model, so the part got 68 % of the plate and was scaled down for no measured reason.

**What happens now.** The worker measures the real footprint after the supports and pad exist, by scanning the STL bytes already in the engine's virtual filesystem (a big model's supports are tens of MB - none of it crosses a message boundary). The adapter compares it with the plate and re-slices smaller only if it genuinely overhangs, by exactly the amount needed, and returns `sumazinta {proc, tekstas}`.

**Margin 3.1 -> 1.0 mm**, measured rather than guessed: the plate is mounted with sideways play (~1 mm), while the edge itself cures - the `T93-remeliai` coupon printed all five frames, the outermost 0.51 mm from the illuminated edge. Usable area 68 % -> 89 %.

**Checked:** STL byte scanning matches an independent computation on two real meshes (1 024 and 81 216 triangles); the scale maths was tested on six cases including asymmetric overhang, and in every one the part fits after shrinking.

**Still open, printer side:** the dashboard should show the one-line reason and move the scale slider, otherwise the card will not mention a shrink that happened. That diff goes to the printer session; the module is published only once both halves are ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)