### PR TITLE
slicer 3.5.0: heavy parts are laid down by four workers, and the support diagnostic stops crying wolf

### DIFF
--- a/wasm/bridge.cpp
+++ b/wasm/bridge.cpp
@@ -1,3 +1,19 @@
+/* ROT-par (2026-09-12): itraukiam PATI `Rotfinder.cpp`, nes kandidatu sarasas
+   (`get_chull_rotations`) ir vertinimo ciklas (`find_min_score`) paslepti jo
+   bevardeje srityje - is kito vertimo vieneto ju nepasieksi, o be ju kandidatu
+   ruozo neatpjausi. PrusaSlicer saltinis lieka nepaliestas (jis parsisiunciamas
+   is naujo), o is `sources.txt` failas isimtas, kad simboliu nebutu dvieju.
+
+   ⚠️ Stovi PIRMAS, pries visas kitas antrastes, ir tai butina: `SLA/SupportTreeTypes.hpp`
+   apibrezia `Slic3r::sla::DOWN` kaip `Vec3d`, o Rotfinder viduje `DOWN` yra `Vec3f`.
+   Itraukus veliau, jo kodas pasiimtu ne ta ir Eigen nebesutaptu tipais. */
+/* `DOWN` yra ir cia, ir `SLA/SupportTreeTypes.hpp` - skirtingais tipais toje
+   pacioje srityje, tad viename vertimo vienete jie nesugyvena. Laikinai
+   perkriksijam TIK sio itraukimo metu; uz jo ribu viskas lieka kaip buvo. */
+#define DOWN ROTFINDER_DOWN
+#include <libslic3r/SLA/Rotfinder.cpp>
+#undef DOWN
+
 /*
  * Tiltas tarp JS ir libslic3r SLA grandines.
  *
@@ -594,6 +610,128 @@ const char *sla_slice_mesh(const float *pos, int ntri, double layer_h, int branc
  * Grazina kampus RADIANAIS apie X ir Y. Taikymo tvarka - kaip
  * `to_transform3f` (Rotfinder.cpp): pirma X, paskui Y.
  */
+/*
+ * ROT-par: tas pats pastatymo kelias, tik KANDIDATU RUOZAS.
+ *
+ * Kodel to reikia: gulinciam ant ploksces modeliui kandidatai imami is
+ * isgaubtinio apvalkalo, ir kiekvienas vertinamas per VISUS trikampius - tad
+ * 275 tukst. trikampiu ziedas su 706 kandidatais uztrunka 6,6 s, o 490 tukst.
+ * modelis - 13,7 s (klausimu sesijos matavimas 09-12). Visa tai sukasi vienoje
+ * gijoje, nors masinoje branduoliu laisva: keturi tokie darbai vienu metu
+ * baigdavo greiciau nei vienas, tad dalijimas virsta tikru greiciu (~4x).
+ *
+ * Kodel `#include` .cpp: kandidatu sarasas (`get_chull_rotations`) ir vertinimo
+ * ciklas (`find_min_score`) gyvena BEVARDEJE srityje Rotfinder.cpp viduje, tad
+ * is kito vertimo vieneto ju nepasieksi. Itraukus faila cia jie tampa musu, o
+ * pats PrusaSlicer saltinis lieka nepaliestas - jis parsisiunciamas is naujo
+ * kiekviename svieziame build'e, ir bet kokia pataisa jame dingtu.
+ * Del to failas isimtas is `sources.txt` - kitaip jo simboliai butu du kartus.
+ *
+ * Darbininkai NESIDERINA tarpusavyje: kandidatu sarasas priklauso tik nuo
+ * modelio, tad kiekvienas gauna ta pati ir pasiima savo dali (`dalis` is
+ * `daliu`). Persiuntinet nieko nereikia, o adapteris tiesiog renka geriausia
+ * is keturiu atsakymu.
+ */
+
+EMSCRIPTEN_KEEPALIVE
+const char *sla_rotfind_ruozas(const float *pos, int ntri, int dalis, int daliu,
+                               double tikslumas, int max_trikampiu)
+{
+    if (!pos || ntri <= 0) {
+        g_json = "{\"klaida\":\"tuscias tinklas\"}";
+        return g_json.c_str();
+    }
+    if (daliu <= 0) daliu = 1;
+    if (dalis < 0) dalis = 0;
+    if (dalis >= daliu) dalis = daliu - 1;
+
+    indexed_triangle_set its;
+    its.vertices.reserve(size_t(ntri) * 3);
+    its.indices.reserve(size_t(ntri));
+    for (int t = 0; t < ntri; ++t) {
+        const int o = t * 9;
+        its.vertices.push_back({pos[o + 0], pos[o + 1], pos[o + 2]});
+        its.vertices.push_back({pos[o + 3], pos[o + 4], pos[o + 5]});
+        its.vertices.push_back({pos[o + 6], pos[o + 7], pos[o + 8]});
+        its.indices.push_back({3 * t, 3 * t + 1, 3 * t + 2});
+    }
+    its_merge_vertices(its, true);
+    if (its_volume(its) < 0.f)
+        for (auto &t : its.indices) std::swap(t[1], t[2]);
+
+    if (max_trikampiu > 0 && its.indices.size() > size_t(max_trikampiu)) {
+        try {
+            its_quadric_edge_collapse(its, uint32_t(max_trikampiu));
+            its_merge_vertices(its, true);
+            if (its_volume(its) < 0.f)
+                for (auto &t : its.indices) std::swap(t[1], t[2]);
+        } catch (...) {}
+    }
+
+    Slic3r::Model model;
+    Slic3r::ModelObject *mo = model.add_object();
+    mo->add_volume(Slic3r::TriangleMesh{its});
+    mo->add_instance();
+
+    Slic3r::DynamicPrintConfig cfg;
+    cfg.set_key_value("pad_around_object", new Slic3r::ConfigOptionBool(true));
+    cfg.set_key_value("support_object_elevation", new Slic3r::ConfigOptionFloat(0.));
+
+    Slic3r::sla::RotOptimizeParams p;
+    p.accuracy(tikslumas > 0 ? float(tikslumas) : 1.f).print_config(&cfg);
+
+    Slic3r::SLAPrintObjectConfig pocfg;
+    pocfg.apply(cfg, true);
+    pocfg.apply(mo->config.get());
+
+    /* Pakeltam modeliui kandidatu saraso nera (einama optimizatoriaus tinkleliu),
+       tad dalijimas cia neturi prasmes - toks atvejis grazinamas su zyme, ir
+       adapteris tiesiog kviecia sena, nedalytа kelia. */
+    if (!Slic3r::sla::is_on_floor(pocfg)) {
+        g_json = "{\"nedalomas\":true}";
+        return g_json.c_str();
+    }
+
+    Slic3r::sla::RotfinderBoilerplate<1000> bp{*mo, p};
+    auto inputs = Slic3r::sla::get_chull_rotations(bp.mesh, bp.max_tries);
+    const size_t viso = inputs.size();
+    bp.max_tries = unsigned(viso ? viso : 1);
+
+    size_t nuo = viso * size_t(dalis) / size_t(daliu);
+    size_t iki = viso * size_t(dalis + 1) / size_t(daliu);
+    if (nuo > viso) nuo = viso;
+    if (iki > viso) iki = viso;
+
+    auto t0 = Clock::now();
+    double balas = 1e30;
+    Slic3r::sla::XYRotation geriausia{{0., 0.}};
+    if (nuo < iki) {
+        auto objfn = [&bp](const Slic3r::sla::XYRotation &rot) {
+            bp.statusfn();
+            return Slic3r::sla::get_supportedness_onfloor_score(
+                bp.mesh, Slic3r::sla::to_transform3f(rot));
+        };
+        auto r = Slic3r::sla::find_min_score<2>(objfn, inputs.begin() + nuo,
+                                                inputs.begin() + iki,
+                                                [&bp] { return bp.stopcond(); });
+        geriausia = Slic3r::sla::XYRotation{{r[0], r[1]}};
+        /* Balas perskaiciuojamas vieną kartą: `find_min_score` grazina tik kampus,
+           o adapteriui reikia, ka lyginti tarp keturiu atsakymu. Viena vertinimas
+           saraso gale nieko nekainuoja salia simtu kandidatu. */
+        balas = Slic3r::sla::get_supportedness_onfloor_score(
+            bp.mesh, Slic3r::sla::to_transform3f(geriausia));
+    }
+    const long ms = ms_since(t0);
+
+    char b[256];
+    std::snprintf(b, sizeof(b),
+        "{\"rx\":%.6f,\"ry\":%.6f,\"balas\":%.9f,\"nuo\":%zu,\"iki\":%zu,"
+        "\"viso\":%zu,\"ms\":%ld}",
+        geriausia[0], geriausia[1], balas, nuo, iki, viso, ms);
+    g_json = b;
+    return g_json.c_str();
+}
+
 EMSCRIPTEN_KEEPALIVE
 const char *sla_rotfind(const float *pos, int ntri, int kuris,
                         double tikslumas, int max_trikampiu)

--- a/wasm/bridge.cpp
+++ b/wasm/bridge.cpp
@@ -433,16 +433,37 @@ static const char *run_chain(TriangleMesh &mesh, double layer_h, bool branching,
         auto zmin_v = [](double a, double b2) { return a < b2 ? a : b2; };
         double zp = 1e30, zh = 1e30, zj = 1e30, zb = 1e30, zcb = 1e30, zdb = 1e30, zped = 1e30, za = 1e30;
         for (const auto &x : t.pillars)      zp   = zmin_v(zp,  x.endpt.z());
-        for (const auto &x : t.heads)        zh   = zmin_v(zh,  x.junction_point().z() - x.width_mm - x.r_back_mm);
+        /* Galvute - atkarpa tarp `pos` (smaigalys ant modelio) ir `junction_point()`
+           (galas ties stulpu), storio `r_back_mm`. Zemiausias jos taskas - zemesnysis is
+           dvieju galu minus spindulys. Anksciau is jungties Z buvo atimamas visas
+           `width_mm`, tarsi galvute smigtu VERTIKALIAI zemyn, o ji i modeli eina istrizai:
+           biustui tai rode -2,088 mm, nors tikras atramu tinklas prasideda nuo 0,000, ir
+           neigiamas skaicius stovejo prie KIEKVIENO modelio - tikros atramos po plokste per
+           sita eilute nebepamatytum (SL-diag, 2026-09-12). */
+        auto galvApacia = [](const auto &x) {
+            return std::min(x.pos.z(), x.junction_point().z()) - x.r_back_mm;
+        };
+        for (const auto &x : t.heads)        zh   = zmin_v(zh,  galvApacia(x));
         for (const auto &x : t.junctions)    zj   = zmin_v(zj,  x.pos.z() - x.r);
         for (const auto &x : t.bridges)      zb   = zmin_v(zb,  zmin_v(x.startp.z(), x.endp.z()) - x.r);
         for (const auto &x : t.crossbridges) zcb  = zmin_v(zcb, zmin_v(x.startp.z(), x.endp.z()) - x.r);
         for (const auto &x : t.diffbridges)  zdb  = zmin_v(zdb, zmin_v(x.startp.z(), x.endp.z()) - x.r);
         for (const auto &x : t.pedestals)    zped = zmin_v(zped, x.pos.z());
-        for (const auto &x : t.anchors)      za   = zmin_v(za,  x.junction_point().z() - x.width_mm - x.r_back_mm);
-        std::printf("zemiausi         stulpai %.3f · galvutes %.3f · jungtys %.3f · tiltai %.3f\n"
-                    "                 kryzminiai %.3f · ant modelio %.3f · pedos %.3f · inkarai %.3f\n",
-                    zp, zh, zj, zb, zcb, zdb, zped, za);
+        for (const auto &x : t.anchors)      za   = zmin_v(za,  galvApacia(x));
+        /* Tuscia kategorija - bruksnys, ne 1e30. Pradine reiksme `1e30` lieka tik tada,
+           kai elementu nera, ir anksciau taip ir buvo atspausdinama: „inkarai
+           1000000000000000019884624838656", nors gretima eilute sako „inkaru 0" (SL-diag). */
+        auto sk = [](double v) {
+            static char buf[8][32]; static int k = 0;
+            char *b = buf[k++ % 8];
+            if (v >= 1e29) std::snprintf(b, 32, "-");
+            else std::snprintf(b, 32, "%.3f", v);
+            return b;
+        };
+        std::printf("zemiausi         stulpai %s · galvutes %s · jungtys %s · tiltai %s\n",
+                    sk(zp), sk(zh), sk(zj), sk(zb));
+        std::printf("                 kryzminiai %s · ant modelio %s · pedos %s · inkarai %s\n",
+                    sk(zcb), sk(zdb), sk(zped), sk(za));
         std::printf("kiekiai          stulpu %zu · galvuciu %zu · jungciu %zu · tiltu %zu · pedu %zu · inkaru %zu\n",
                     t.pillars.size(), t.heads.size(), t.junctions.size(),
                     t.bridges.size(), t.pedestals.size(), t.anchors.size());

--- a/wasm/slicer-wasm-worker.js
+++ b/wasm/slicer-wasm-worker.js
@@ -10,7 +10,7 @@
 const BAZE = self.SLA_BAZE || './';
 importScripts(BAZE + 'sla-web.js');
 
-let M = null, sliceMeshFn = null, sl1Fn = null, previewFn = null, rotFn = null, vardas = 'spaudinys';
+let M = null, sliceMeshFn = null, sl1Fn = null, previewFn = null, rotFn = null, rotRuozasFn = null, vardas = 'spaudinys';
 let setParamsFn = null;
 let dabartinisId = 0;
 
@@ -183,6 +183,13 @@ const paruostas = createSLA({ locateFile: function (p) { return BAZE + p; } }).t
      nepaduoti, ir viskas laikesi ant C pusės sargu (SL-args). */
   rotFn = m.cwrap('sla_rotfind', 'string',
                   ['number', 'number', 'number', 'number', 'number']);
+  /* ROT-par: tas pats pastatymas, tik kandidatu ruozas (dalis is daliu). Senas
+     variklis to iejimo neturi - tada `cwrap` grazina funkcija, kuri luztu
+     kviečiama, tad tikrinam, ar simbolis apskritai yra. */
+  rotRuozasFn = m._sla_rotfind_ruozas
+    ? m.cwrap('sla_rotfind_ruozas', 'string',
+              ['number', 'number', 'number', 'number', 'number', 'number'])
+    : null;
   return m;
 });
 
@@ -277,6 +284,28 @@ self.onmessage = async function (ev) {
       const kampai = JSON.parse(atsakymas);
       if (kampai.klaida) { self.postMessage({ tipas: 'klaida', id: z.id, tekstas: kampai.klaida }); return; }
       self.postMessage({ tipas: 'atsakymas', id: z.id, kampai: kampai });
+
+    } else if (z.tipas === 'pakrypimas_ruozas') {
+      /* ROT-par: vienas is keliu darbininku ivertina savo kandidatu dali.
+         Kandidatu sarasas priklauso tik nuo modelio, tad visi darbininkai gauna ta
+         pati ir nesiderina tarpusavyje; adapteris renka maziausia `balas`. */
+      if (!rotRuozasFn) {
+        self.postMessage({ tipas: 'atsakymas', id: z.id, ruozas: { nepalaikoma: true } });
+        return;
+      }
+      const pos = new Float32Array(z.pos);
+      const ptr = M._malloc(pos.byteLength);
+      M.HEAPF32.set(pos, ptr >> 2);
+      let atsakymas;
+      try {
+        atsakymas = rotRuozasFn(ptr, pos.length / 9, z.dalis | 0, z.daliu | 0,
+                                z.tikslumas || 1.0, z.maxTrikampiu || 0);
+      } finally {
+        M._free(ptr);
+      }
+      const ruozas = JSON.parse(atsakymas);
+      if (ruozas.klaida) { self.postMessage({ tipas: 'klaida', id: z.id, tekstas: ruozas.klaida }); return; }
+      self.postMessage({ tipas: 'atsakymas', id: z.id, ruozas: ruozas });
 
     } else if (z.tipas === 'geometrija') {
       const dalys = {};

--- a/wasm/slicer-wasm.js
+++ b/wasm/slicer-wasm.js
@@ -139,16 +139,17 @@ const ROT_MAX_TRI = 0;
 
 /* ROT-par: nuo kiek trikampiu verta dalyti pastatyma keliems darbininkams.
  *
- * Tiesiogiai darbininkuose (2026-09-12): 300 tukst. trikampiu biustas 7,37 ->
- * 1,66 s (4,4x), 81 tukst. bareljefas 0,42 -> 0,24 s, 1 tukst. puodelis 0,05 ->
- * 0,09 s (leciau - kopija keturiems kainuoja daugiau nei darbas).
+ * Svarus matavimas (2026-09-12, matoma Chrome kortele, masina rami, po 3 kartus,
+ * mediana), per ta pati kelia, kuri naudoja pultas:
+ *   biustas, 300 tukst. trikampiu: 4,80 s -> 1,48 s (3,2x), kampas sutampa;
+ *   bareljefas, 81 tukst.: senu keliu vos 0,23 s - dalyti nera ko.
+ * Riba 150 tukst. todel, kad zemiau jos paieska ir taip trunka mazai (sekunde ar
+ * maziau), tad keturi darbininkai sutaupytu desimtasias, o kainuotu tinklo kopijas.
  *
- * Bet per ADAPTERI, kaip naudoja pultas, vaizdas kitas: po paieskos pagrindineje
- * gijoje sukasi `fitOnPlate`, biustui 2 s, ir jo dalijimas neliecia. Tad zmogus
- * biustui pajunta ~2x (apie 10,6 -> 5,4 s), o bareljefui naudos nebera visai -
- * matuota net siek tiek leciau. Todel riba 150 tukst.: keturi darbininkai tik ten,
- * kur jie sutaupo kelias sekundes; visi kiti - senu keliu.
- * Kampas visais atvejais SUTAPO su senuoju keliu. */
+ * ⚠️ Ankstesni tos pacios dienos skaiciai (per adapteri „tik 2x", „talpinimas 2 s",
+ * 13-14 s) buvo KLAIDINGI: juos gadino PASLEPTA naršykles kortele (fone naršykle
+ * riboja procesoriu - tas pats matavimas paslėptoje kortelėje davė 10,5 s, matomoje
+ * 4,6 s) ir nepilna testo transformacija. `fitOnPlate` biustui trunka 0,16 s. */
 const ROT_PAR_NUO = 150000;
 
 let TELKINYS = null;

--- a/wasm/slicer-wasm.js
+++ b/wasm/slicer-wasm.js
@@ -137,7 +137,83 @@ export async function autoOrientFast(pos) {
  * pastatymas nesikeicia BENT desimt skirtingu modeliu. */
 const ROT_MAX_TRI = 0;
 
+/* ROT-par: nuo kiek trikampiu verta dalyti pastatyma keliems darbininkams.
+ *
+ * Tiesiogiai darbininkuose (2026-09-12): 300 tukst. trikampiu biustas 7,37 ->
+ * 1,66 s (4,4x), 81 tukst. bareljefas 0,42 -> 0,24 s, 1 tukst. puodelis 0,05 ->
+ * 0,09 s (leciau - kopija keturiems kainuoja daugiau nei darbas).
+ *
+ * Bet per ADAPTERI, kaip naudoja pultas, vaizdas kitas: po paieskos pagrindineje
+ * gijoje sukasi `fitOnPlate`, biustui 2 s, ir jo dalijimas neliecia. Tad zmogus
+ * biustui pajunta ~2x (apie 10,6 -> 5,4 s), o bareljefui naudos nebera visai -
+ * matuota net siek tiek leciau. Todel riba 150 tukst.: keturi darbininkai tik ten,
+ * kur jie sutaupo kelias sekundes; visi kiti - senu keliu.
+ * Kampas visais atvejais SUTAPO su senuoju keliu. */
+const ROT_PAR_NUO = 150000;
+
+let TELKINYS = null;
+
+/* Kiek darbininku: iki keturiu (astuoni prideda mazai - klausimu sesijos
+   matavimas), bet ne daugiau nei laisvu branduoliu. Kiekvienas darbininkas
+   laiko savo variklio egzemplioriu ir tinklo kopija, tad irenginiui su mazai
+   atminties (telefonas) dalijimo NEDAROM - geriau lėčiau nei nulūžusi kortele.
+   Esamas darbininkas `W` naudojamas kaip vienas is ju: vienu varikliu maziau. */
+function telkinys() {
+  if (TELKINYS) return TELKINYS;
+  const nav = (typeof navigator !== 'undefined') ? navigator : {};
+  const branduoliai = nav.hardwareConcurrency || 2;
+  const atmintisGb = nav.deviceMemory || 8;
+  const kiek = atmintisGb < 4 ? 1 : Math.max(1, Math.min(4, branduoliai - 1));
+  TELKINYS = [darbininkas()];
+  for (let i = 1; i < kiek; i++) TELKINYS.push(naujasDarbininkas());
+  return TELKINYS;
+}
+
+/* Kandidatu ruozai lygiagreciai. Grazina {rx, ry} arba null - tada kvieciantis
+   eina senuoju keliu. Null reiskia ne klaida, o „siuo atveju nedalinam":
+   senas variklis be ruozu iejimo, pakeltas modelis (ten kandidatu saraso nera)
+   arba irenginys, kuriam telkinys iš vieno darbininko. */
+async function pastatymasDalimis(pos, onProgress) {
+  const ts = telkinys();
+  if (ts.length < 2) return null;
+  let baigta = 0;
+  const atsakymai = await Promise.all(ts.map((w, i) => {
+    const kopija = new Float32Array(pos);
+    return paklauskKa(w,
+      { tipas: 'pakrypimas_ruozas', pos: kopija.buffer, dalis: i, daliu: ts.length },
+      [kopija.buffer])
+      .then(z => {
+        baigta++;
+        if (onProgress) onProgress(Math.round(baigta / ts.length * 95), 100,
+                                   'ieskoma geriausios padeties');
+        return z.ruozas;
+      });
+  }));
+  if (atsakymai.some(a => !a || a.nepalaikoma || a.nedalomas)) return null;
+  const tikri = atsakymai.filter(a => a.nuo < a.iki);
+  if (!tikri.length) return null;
+  const geriausias = tikri.reduce((a, b) => (b.balas < a.balas ? b : a));
+  return { rx: geriausias.rx, ry: geriausias.ry };
+}
+
 export async function autoOrientPro(pos, onProgress, o) {
+  /* ROT-par: sunkus modelis - keli darbininkai. Retinimo eksperimentas eina
+     senu keliu, nes ruozu iejimas retina kitaip ir palyginimai nesutaptu. */
+  const retinam = o && o.maxTrikampiu;
+  if (!retinam && pos.length / 9 >= ROT_PAR_NUO) {
+    let k = null;
+    try { k = await pastatymasDalimis(pos, onProgress); } catch (e) { k = null; }
+    if (k) {
+      const tr = Object.assign(BAZE.makeTransform(), {
+        rxDeg: k.rx * 180 / Math.PI,
+        ryDeg: k.ry * 180 / Math.PI,
+      });
+      const best = fitOnPlate(pos, tr);
+      if (onProgress) onProgress(100, 100, 'baigta');
+      return best;
+    }
+  }
+
   const kopija = new Float32Array(pos);            // savininkyste keliauja i gija
   let r;
   try {
@@ -183,23 +259,26 @@ const ADRESAS = new URL('./', import.meta.url).href;
    pats, tad neprisegtas vardas ten reikstu sena narsykles kopija. */
 const BAZES_FAILAS = 'slicer-core.js';
 
-function darbininkas() {
-  if (W) return W;
-  /*
-   * ⚠️ Darbininko NEGALIMA kurti tiesiai is kito domeno: pultas sukasi ant
-   * printerio (http://tinymaker.local), o modulis guli gh-pages, ir narsykle
-   * toki `new Worker(https://...)` atmeta (SecurityError).
-   *
-   * Apeinam standartiskai: pasidarom mazyti vietini darbininka, kuris pats
-   * per `importScripts` parsisiunčia tikraji - tam kito domeno riba negalioja.
-   */
+/*
+ * ⚠️ Darbininko NEGALIMA kurti tiesiai is kito domeno: pultas sukasi ant
+ * printerio (http://tinymaker.local), o modulis guli gh-pages, ir narsykle
+ * toki `new Worker(https://...)` atmeta (SecurityError).
+ *
+ * Apeinam standartiskai: pasidarom mazyti vietini darbininka, kuris pats
+ * per `importScripts` parsisiunčia tikraji - tam kito domeno riba negalioja.
+ *
+ * Iskelta i atskira funkcija del ROT-par: pastatymo telkiniui reikia keliu
+ * tokiu pat darbininku. Visi jie atsako per ta pati `laukia` sarasa - numeriai
+ * `kitasId` unikalus visam moduliui, tad susipainioti negali.
+ */
+function naujasDarbininkas() {
   const uzkrovejas =
     'self.SLA_BAZE=' + JSON.stringify(ADRESAS) + ';' +
     'importScripts(' + JSON.stringify(ADRESAS + 'slicer-wasm-worker.js') + ');';
   const url = URL.createObjectURL(new Blob([uzkrovejas], { type: 'text/javascript' }));
-  W = new Worker(url);
+  const w = new Worker(url);
   URL.revokeObjectURL(url);
-  W.onmessage = (ev) => {
+  w.onmessage = (ev) => {
     const z = ev.data || {};
     const p = laukia.get(z.id);
     if (z.tipas === 'eiga') { if (p && p.eiga) p.eiga(z); return; }
@@ -208,15 +287,24 @@ function darbininkas() {
     if (z.tipas === 'klaida') p.blogai(new Error(z.tekstas));
     else p.gerai(z);
   };
+  return w;
+}
+
+function darbininkas() {
+  if (!W) W = naujasDarbininkas();
   return W;
 }
 
-function paklausk(zinute, perduoti, eiga) {
+function paklauskKa(w, zinute, perduoti, eiga) {
   const id = kitasId++;
   return new Promise((gerai, blogai) => {
     laukia.set(id, { gerai, blogai, eiga });
-    darbininkas().postMessage({ ...zinute, id }, perduoti || []);
+    w.postMessage({ ...zinute, id }, perduoti || []);
   });
+}
+
+function paklausk(zinute, perduoti, eiga) {
+  return paklauskKa(darbininkas(), zinute, perduoti, eiga);
 }
 
 /* ------------------------------------------------------------------ pjaustymas */

--- a/wasm/slicer-wasm.js
+++ b/wasm/slicer-wasm.js
@@ -114,12 +114,40 @@ export async function autoOrientFast(pos) {
  * @param onProgress (done, total, phase) - tokia pat forma, kaip `slice()`
  * @returns { tr, size, fit } - lygiai tas pats, ka grazina `autoOrient`
  */
-export async function autoOrientPro(pos, onProgress) {
+/* Kiek trikampiu palikti PASTATYMO paieskai.
+ *
+ * Kiekvienas apgaubo kandidatas vertinamas per VISUS trikampius, tad laikas auga
+ * su tinklo dydziu, ne su daikto sudetingumu: 300 tukst. trikampiu biustas vercia
+ * laukti 9 s, o tukstancio trikampiu puodelis pastatomas akimirksniu. Variklis moka
+ * suretinti tinkla pries paieska nuo 08-20, bet adapteris ribos nepaduodavo, tad ji
+ * buvo isjungta.
+ *
+ * 50 tukst. - is matavimo (2026-09-12, stendas su tikru varikliu): biustas 9,01 ->
+ * 5,06 s, o pasirinkti kampai IDENTISKI ir ties 100, 50 ir 25 tukstanciais. Tai
+ * suprantama: pastatymas yra bendros formos klausimas, o ne detaliu - ir suslicinamas
+ * vis tiek lieka PILNAS modelis, retinamas tik vertinimui.
+ *
+ * `maxTrikampiu: 0` isjungia - reikalinga lyginant su PrusaSlicer etalonu. */
+/* ⛔ ISJUNGTA (0) - patikrinta 2026-09-12 ir NEPRAEJO. Su 50 tukst. riba
+ * bareljefas guldomas ant KITO sono (0/-90 virsta 0/0), o biusto kampai irgi
+ * pasikeicia; be to mazam modeliui pats retinimas kainuoja daugiau, nei sutaupo
+ * (bareljefas 0,52 -> 2,02 s). Pirmas matavimas trimis modeliais buvo sutapes
+ * atsitiktinai, ir jo iSvada buvo klaidinga.
+ * Parametras paliktas eksperimentams; itraukiant ji reiketu pirma irodyti, kad
+ * pastatymas nesikeicia BENT desimt skirtingu modeliu. */
+const ROT_MAX_TRI = 0;
+
+export async function autoOrientPro(pos, onProgress, o) {
   const kopija = new Float32Array(pos);            // savininkyste keliauja i gija
   let r;
   try {
     r = await paklausk(
-      { tipas: 'pakrypimas', pos: kopija.buffer, kauke: 1 },
+      { tipas: 'pakrypimas', pos: kopija.buffer, kauke: 1,
+        /* Tinklo retinimas PRIES paieska. Variklis tai moka nuo 08-20, bet
+           adapteris ribos nepadavė, tad ji visada buvo isjungta: kiekvienas
+           apgaubo kandidatas vertinamas per VISUS trikampius. Nulis = kaip buvo. */
+        maxTrikampiu: (o && o.maxTrikampiu !== undefined)
+          ? o.maxTrikampiu : ROT_MAX_TRI },
       [kopija.buffer],
       (z) => { if (onProgress) onProgress(z.proc || 0, 100, z.etapas); });
   } catch (e) {

--- a/wasm/sources.txt
+++ b/wasm/sources.txt
@@ -81,7 +81,13 @@ libslic3r/SLA/Pad.cpp
 libslic3r/SLA/PrinterCorrections.cpp
 libslic3r/SLA/RasterBase.cpp
 libslic3r/SLA/RasterToPolygons.cpp
-libslic3r/SLA/Rotfinder.cpp
+# libslic3r/SLA/Rotfinder.cpp - NEKOMPILIUOJAMAS atskirai (ROT-par, 2026-09-12).
+# Ji itraukia `bridge.cpp`, nes pastatymo virtuve (kandidatu sarasas
+# `get_chull_rotations`, vertinimas `find_min_score`) paslepta bevardeje
+# srityje ir is kito failo nepasiekiama. Itraukus i savo vertima galima
+# ivertinti KANDIDATU RUOZA, o tai leidzia darba padalyti keturiems
+# darbininkams. PrusaSlicer saltinis lieka NEPALIESTAS - jis kaskart
+# parsisiunciamas is naujo, tad pataisos jame neislikты.
 libslic3r/SLA/SpatIndex.cpp
 libslic3r/SLA/SupportIslands/EvaluateNeighbor.cpp
 libslic3r/SLA/SupportIslands/ExpandNeighbor.cpp


### PR DESCRIPTION
**Draft on purpose - waits for its turn.** This should merge and ship only after `FIT-real` (#138) is flashed and checked with a print, so that only one thing changes at a time.

## What it does

Careful placement takes candidate rotations from the model's convex hull and scores each one against every triangle, all in one thread. A 300 000 triangle bust made people wait almost five seconds while the machine had cores to spare.

For parts with **150 000 triangles or more**, the search is now split across a pool of workers - the existing one plus up to three more, never more than free cores, and **none at all on a device reporting under 4 GB of memory**. Each worker scores its own slice of the candidate list and the lowest score wins. Everything smaller, an old engine without the new entry, or a lifted part takes the old path unchanged.

## Measured

Visible Chrome tab, quiet machine, three runs each, median, through the same path the dashboard uses:

| Model | Old path | With the pool |
|---|---|---|
| bust, 300 000 triangles | 4.80 s | **1.48 s (3.2x)**, same angle |
| bas-relief, 81 000 | 0.23 s | 0.24 s (not split) |

The chosen rotation matched the undivided search on every model tried.

Earlier numbers from the same evening ("only 2x", "placement takes 2 s") were wrong: they came from a hidden browser pane that the browser throttles in the background - the same search took 10.5 s hidden and 4.6 s visible. `fitOnPlate` takes 0.16 s and is deliberately left on the main thread.

## How the engine got at the search

The candidate list (`get_chull_rotations`) and the scoring loop (`find_min_score`) sit in an anonymous namespace inside PrusaSlicer's `Rotfinder.cpp`. So that file is **included into `bridge.cpp`** and removed from `sources.txt`; PrusaSlicer's source stays untouched, because it is re-downloaded on a clean build. `DOWN` exists both there and in `SupportTreeTypes.hpp` with different types in the same namespace, so the name is renamed for the duration of that one include.

Note for anyone rebuilding in place: `build.sh link` links every object it finds, so an old `obj/libslic3r_SLA_Rotfinder.o` from before this change gives duplicate symbols. A clean build never has it.

## Not done here

- **Not published.** No module version bump yet.
- Memory use with four engines is not measured precisely - a page cannot read worker memory. The only guard is `navigator.deviceMemory`.
- `autoOrientPro` accepts a triangle cap for experiments, **off by default**: decimating before the search changed the chosen side of the bas-relief.

## When it ships

The engine is rebuilt here anyway, so the same module release should carry the queued `SL-diag` diagnostic fixes and the small audit items for 3.4.1 (`telpa: null` when the footprint could not be measured, a triangle ceiling for the second FIT-real pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)