### PR TITLE
slicer card: the percent field's up arrow steps up again

### DIFF
--- a/web/parts/slicer.js
+++ b/web/parts/slicer.js
@@ -427,7 +427,12 @@ const slicerScaleUI=b=>{
   if(pr&&!scaleDragging){pr.min=floor; pr.max=top; pr.step=step; pr.value=shown;}
   /* Skaiciu laukelis lieka platesnis uz juosta: iraseiciau bet koki procenta, o
      „netelpa" sarga pasakys, jei perlenkta - juosta tik neveda ten uz rankos. */
-  if(pp){pp.min=SCALE_MIN_PCT; pp.step=step; pp.value=shown;}
+  /* `min` turi guleti ant to paties tinklelio kaip `step`: narsykle rodykles
+     zingsni skaiciuoja NUO `min`. Su min 0,1 ir zingsniu 1 leistinos reiksmes
+     buvo 100,1 · 101,1…, tad rodykle aukstyn is 100 nesdavo i 100,1, o tas
+     apvalinamas zemyn atgal i 100 - procentu rodykle aukstyn neveikdavo niekur,
+     zemyn veikdavo (V 09-13). Rasyti ranka maziau uz min vis tiek galima. */
+  if(pp){pp.min=step<1?SCALE_MIN_PCT:1; pp.step=step; pp.value=shown;}
   if(pm)pm.value=b.size[2].toFixed(1);
 };
 /* Tempimo zyme. `pointerup` ir `change` - abu: pirmas pagauna pele/pirsta, antras


### PR DESCRIPTION
Reported by V on the printer: in the scale popup the mm field's up arrow keeps growing the part past the plate (and the card says it no longer fits), but the percent field's up arrow does nothing.

**Cause, measured in the offline demo:** a number input counts its arrow steps from `min`. `slicerScaleUI` set `min = 0.1` with `step = 1`, so the valid values were 100.1, 101.1, … The up arrow went 100 → 100.1, which the card rounds down for display (on purpose, so a shown value never overflows the plate) back to 100. Up never moved anywhere, down did.

**Fix:** `min` sits on the same grid as `step`: 1 for whole-percent steps, 0.1 for tenths. Typing a smaller value by hand still works (`popScaleApply` clamps to 0.1 %).

**Checked** in the offline demo: 100 → 101 → 102 → 101; at the plate limit 148 → 149 → 150, and the card switches to "Too large - width +1%".

Only `web/parts/slicer.js`; reaches the printer with the next dashboard flash by the printer session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)