### PR TITLE
slicer card: the firmware's own module version is 3.5.0

### DIFF
--- a/web/parts/slicer.js
+++ b/web/parts/slicer.js
@@ -329,7 +329,7 @@ const slicerLoadMod=async()=>{
      nebelieka. 08-24 buvo atvirkscias atvejis - kortelej jau gulejo 3.2.0, o
      pultas vis dar prase 3.1.1, tad kiekvienas krovimas eidavo per interneta
      (1,1 MB) ir pazadas veikti be tinklo buvo sulauzytas. */
-  const SV='3.4.0';
+  const SV='3.5.0';
   slicerMod=await loadModule('slicer-wasm-'+SV,SV,
       'https://slibbinas.github.io/TinyMakerWifi/lib/slicer-wasm-'+SV+'.js');
   /* Piliuleje - `slicerMod.VERSION`, t. y. ka atsakė PATS uzsikroves modulis, o ne


### PR DESCRIPTION
Module 3.5.0 (heavy parts laid down by four workers, support diagnostic fixed) is published on gh-pages and installed on the printer's SD card. The dashboard constant `SV` still said `3.4.0`: a card with a module installed already overrides it (`loadModule`), but a fresh card with nothing installed would fetch 3.4.0.

One line, `web/parts/slicer.js:332`. Goes to the printer in the same dashboard flash as #140 and #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)