### PR TITLE
slicer card: Discard stays on the right under a long result line

### DIFF
--- a/web/parts/slicer.css
+++ b/web/parts/slicer.css
@@ -108,5 +108,5 @@
    faktai bei visa desine kolona. Suslicinus zmogus ziuri butent i ta vieta, tad
    sokinejantis makletas yra brangesnis uz tuscia eilute, kurios niekas nepastebi.
    Klase `tuscia` lieka - ji tebeslepia „Discard", kol nera ka atmesti. */
-#slicerResRow{margin:9px 0;min-height:1.9em}
+#slicerResRow{margin:9px 0;min-height:1.9em}/* „Discard" VISADA desineje (V 09-13). Bendra `.calRow` leidzia persikelti i nauja eilute, tad ilgas rezultatas („Scaled down … and they still do …") uzimdavo visa ploti, o „Discard" nukrisdavo po juo i KAIRE (ismatuota: 395 px nuo desinio krasto). Be persikelimo tekstas lauzosi savo stulpelyje (`min-width:0`), o `baseline` laiko „Discard" pirmos jo eilutes aukstyje. */#slicerResRow{flex-wrap:nowrap;align-items:baseline}#slicerProg{min-width:0}
 #slicerResRow.tuscia #slicerDiscardLink{display:none}


### PR DESCRIPTION
Reported by V on the printer (build d12f9f6): after a scale-down that still does not fit, the result line is long enough to wrap, and **Discard** jumped to its own line at the left. It belongs on the right, right under the button it undoes (V 08-20).

**Cause, measured in the offline demo:** the result row uses the shared `.calRow`, which has `flex-wrap: wrap`. A long text span claimed the full row width, so the link wrapped below it at the left edge (395 px from the right).

**Fix** (`web/parts/slicer.css`, result row only): no wrapping, `min-width:0` on the text so it breaks inside its own column, `align-items: baseline` so Discard sits level with the first line of text.

**Checked** in the offline demo, `cup15.stl` at full scale, sliced ("Scaled down 26.8% … and they still do …"): Discard's right edge equals Send to printer's at 1024 px wide (970 / 970) and at phone width 375 px (336 / 336); a short result line keeps its old height.

Only `web/parts/slicer.css`; reaches the printer with the next dashboard flash by the printer session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)