### PR TITLE
release 0.17.2 (beta): the dashboard catches up with slicer module 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,51 @@ the upstream TinyMaker3D firmware is `1.0.2`. Format follows
 Credits: features are by **Viktoras Šidlauskas ([@slibbinas](https://github.com/slibbinas))**
 unless noted. Community contributors are tagged inline.
 
+## [0.17.2] - 2026-09-13 (beta)
+
+A slicer fix-up for the 0.17 beta. The firmware itself is unchanged; everything here is
+in the dashboard's slicer card and in the slicer module it loads. It only matters if
+you switched on **Settings → STL slicer in the dashboard** - the slicer stays off by
+default until 1.0.0.
+
+This release also pairs the dashboard with slicer module 3.5.0, which is already
+published. A 0.17.1 dashboard can install that module, but it was built for an older
+one and does not know how the new module decides whether a part fits.
+
+### Changed
+
+- **Parts get more of the plate.** The slicer used to keep 3.1 mm clear on every side
+  of the whole model - the room a support foot and the pad rim need - so a part could
+  use only 68 % of the plate and was scaled down for no measured reason. The margin is
+  now 1.0 mm, measured on a printed edge coupon (the screen cures to within 0.5 mm of
+  its lit edge; the rest is the plate's sideways play). Usable area goes from 68 % to
+  89 %.
+- **The fit check happens after the supports exist.** Instead of guessing from the
+  worst case, the slicer now measures the real footprint of the part with its supports
+  and pad. Only if that really reaches past the plate is the part sliced again, smaller
+  by exactly what is needed.
+- **Heavy models are laid down faster.** For parts with 150 000 triangles or more, the
+  careful placement search is split across up to four workers (never on a device with
+  under 4 GB of memory). A 300 000 triangle bust went from about 4.8 s to 1.5 s, with
+  the same result.
+
+### Fixed
+
+- **A part scaled down to fit is now said out loud.** The card shows "Scaled down N% -
+  the supports reached past the plate.", and if the part still overhangs after that, it
+  says so and asks you to scale it down by hand. The scale slider and the height field
+  move to the new size, so the next nudge does not push the part back past the edge.
+- **The size line under the file name follows that scale-down.** It kept showing the
+  size from before, so someone printing a part that must be a real size (a ring, a
+  bracket on a shaft) read the old numbers and got a smaller part.
+- **The percent field's up arrow grows the part again.** It did nothing anywhere; the
+  down arrow worked.
+- **Discard stays on the right when the result line is long.** When a part still
+  overhangs after the scale-down, the longer message pushed the Discard button onto its
+  own line on the left. The message now wraps in its own column.
+- **A clean card asks for slicer module 3.5.0.** A card that already had a module
+  installed was not affected - the installed one is always used.
+
 ## [0.17.1] - 2026-09-12 (beta)
 
 ### Fixed

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -162,7 +162,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
 </div>
 
 <header class="hero">
-  <span class="badge">User Manual · v0.17.1</span>
+  <span class="badge">User Manual · v0.17.2</span>
   <h1>TinyMakerWifi</h1>
   <p class="tag">WiFi, wireless upload &amp; over-the-air updates for the TinyMaker resin printer</p>
   <p class="author">by <b>Viktoras Šidlauskas</b> · <a href="https://github.com/slibbinas">@slibbinas</a> · <a href="https://tinymakerwifi.com">tinymakerwifi.com</a></p>
@@ -901,7 +901,7 @@ window.addEventListener('DOMContentLoaded',window.tmSyncSite);
 </div>
 
 <footer>
-  <p>TinyMakerWifi · User Manual · v0.17.1 · by Viktoras Šidlauskas · <a href="https://tinymakerwifi.com">tinymakerwifi.com</a><br>
+  <p>TinyMakerWifi · User Manual · v0.17.2 · by Viktoras Šidlauskas · <a href="https://tinymakerwifi.com">tinymakerwifi.com</a><br>
   Based on the open-source <a href="https://tinymaker3d.com/">TinyMaker 3D printer</a>. Firmware MIT-licensed.</p>
 </footer>
 </body>

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,7 @@ lib_deps =
  
 build_flags =
     -D CORE_DEBUG_LEVEL=0
-    -DFIRMWARE_VERSION=\"0.17.1\"
+    -DFIRMWARE_VERSION=\"0.17.2\"
 
 ; Po kiekvieno USB buildo sulipdo bootloader+partitions+app i firmware-full.bin
 ; (žr. scripts/post_merge_bin.py) - failas skirtas pirmam flash'inimui per USB.
@@ -64,7 +64,7 @@ lib_deps =
     knolleary/PubSubClient@^2.8
 build_flags =
     -D CORE_DEBUG_LEVEL=0
-    -DFIRMWARE_VERSION=\"0.17.1\"
+    -DFIRMWARE_VERSION=\"0.17.2\"
 upload_protocol = espota
 upload_port = tinymaker.local
 extra_scripts =


### PR DESCRIPTION
Version bump for the 0.17.2 beta. No firmware source changes since 0.17.1 - only the dashboard's slicer card and the slicer module it loads.

- `platformio.ini` `FIRMWARE_VERSION` 0.17.1 -> 0.17.2 (both environments)
- `docs/manual/index.html` badge and footer -> v0.17.2
- `CHANGELOG.md` entry `[0.17.2] - 2026-09-13 (beta)`: FIT-edge, FIT-real (#137, #138), faster placement for heavy parts (#139), and the card fixes #140, #141, #142, #143

**Why now:** slicer module 3.5.0 is already published, and a 0.17.1 dashboard can install it without knowing how the new module decides whether a part fits. 0.17.2 pairs the two.

**Checked on the printer** (build d12f9f6 = main before #143, module 3.5.0): FIT-real tests T-125..T-127 (with 3.4.0), the size line after a scale-down (T-128) and the percent up arrow (T-129). #143 (CSS only) is checked in the offline demo, not on the printer.

After merge, the release is cut from `main` with `scripts/release.py --beta --notes-file release-notes-0.17.2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
